### PR TITLE
COMP: Provide better feedback for tests

### DIFF
--- a/Testing/niftilib/nifti_test.c
+++ b/Testing/niftilib/nifti_test.c
@@ -158,6 +158,11 @@ void compare_reference_image_values(nifti_image const * const reference_image, n
 
 int main (int argc, char *argv[])
 {
+  if (argc > 1)
+  {
+    printf("The test program takes no arguments: %s", argv[0]);
+    return EXIT_FAILURE;
+  }
   char TEMP_STR[256];
   nifti_set_debug_level(3);
   int Errors=0;

--- a/Testing/niftilib/nifti_test2.c
+++ b/Testing/niftilib/nifti_test2.c
@@ -6,6 +6,12 @@
 #include <nifti1_io.h>
 int main (int argc, char *argv[])
 {
+  if (argc > 1)
+  {
+    printf("The test program takes no arguments: %s", argv[0]);
+    return EXIT_FAILURE;
+  }
+
   /*
    * create a 'dummy' image
    */


### PR DESCRIPTION
These two tests are not intended to take command line inputs.
Provide an message describing the intent of the testing
program usage and exit with failure.