### PR TITLE
SYTLE: Remove *_SRC variables that were used once

### DIFF
--- a/cifti/CMakeLists.txt
+++ b/cifti/CMakeLists.txt
@@ -1,9 +1,8 @@
 find_package(expat REQUIRED)
 
 set(NIFTI_CIFTILIB_NAME ${NIFTI_PACKAGE_PREFIX}cifti)
-set(CIFTILIB_SRC afni_xml.c afni_xml_io.c)
 
-add_library(${NIFTI_CIFTILIB_NAME} ${CIFTILIB_SRC} )
+add_library(${NIFTI_CIFTILIB_NAME} afni_xml.c afni_xml_io.c )
 target_link_libraries( ${NIFTI_CIFTILIB_NAME} PUBLIC EXPAT::EXPAT ${NIFTI_PACKAGE_PREFIX}nifti2)
 target_include_directories(${NIFTI_CIFTILIB_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/fsliolib/CMakeLists.txt
+++ b/fsliolib/CMakeLists.txt
@@ -1,11 +1,8 @@
-
-set(FSLIOLIB_SRC fslio.c)
-
 # Michael Hanke 2004-04-25:
 # Restructure the file to match those of niftilib and znzlib
 set(NIFTI_FSLIOLIB_NAME ${NIFTI_PACKAGE_PREFIX}fslio)
 
-add_library(${NIFTI_FSLIOLIB_NAME} ${FSLIOLIB_SRC} )
+add_library(${NIFTI_FSLIOLIB_NAME} fslio.c )
 target_link_libraries( ${NIFTI_FSLIOLIB_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}niftiio)
 target_include_directories(${NIFTI_FSLIOLIB_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/nifti2/CMakeLists.txt
+++ b/nifti2/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(NIFTI_NIFTILIB2_NAME ${NIFTI_PACKAGE_PREFIX}nifti2)
-set(NIFTILIB2_SRC nifti2_io.c)
 
-add_library(${NIFTI_NIFTILIB2_NAME} ${NIFTILIB2_SRC} )
+add_library(${NIFTI_NIFTILIB2_NAME} nifti2_io.c )
 target_link_libraries( ${NIFTI_NIFTILIB2_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}niftiio)
 target_include_directories(${NIFTI_NIFTILIB2_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/nifticdf/CMakeLists.txt
+++ b/nifticdf/CMakeLists.txt
@@ -1,9 +1,6 @@
-
-set(NIFTICDFLIB_SRC nifticdf.c)
-
 set(NIFTI_CDFLIB_NAME ${NIFTI_PACKAGE_PREFIX}nifticdf)
 
-add_library(${NIFTI_CDFLIB_NAME} ${NIFTICDFLIB_SRC} )
+add_library(${NIFTI_CDFLIB_NAME} nifticdf.c )
 target_link_libraries(${NIFTI_CDFLIB_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}niftiio)
 target_include_directories(${NIFTI_CDFLIB_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/niftilib/CMakeLists.txt
+++ b/niftilib/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(NIFTILIB_SRC nifti1_io.c)
-
 set(NIFTI_NIFTILIB_NAME ${NIFTI_PACKAGE_PREFIX}niftiio)
-add_library(${NIFTI_NIFTILIB_NAME} ${NIFTILIB_SRC} )
+add_library(${NIFTI_NIFTILIB_NAME} nifti1_io.c )
 target_link_libraries( ${NIFTI_NIFTILIB_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}znz)
 target_include_directories(${NIFTI_NIFTILIB_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/znzlib/CMakeLists.txt
+++ b/znzlib/CMakeLists.txt
@@ -1,8 +1,6 @@
-set(ZNZLIB_SRC znzlib.c)
-
 set(NIFTI_ZNZLIB_NAME ${NIFTI_PACKAGE_PREFIX}znz)
 
-add_library(${NIFTI_ZNZLIB_NAME} ${ZNZLIB_SRC} )
+add_library(${NIFTI_ZNZLIB_NAME} znzlib.c )
 target_link_libraries( ${NIFTI_ZNZLIB_NAME} PUBLIC ${NIFTI_ZLIB_LIBRARIES} )
 target_include_directories(${NIFTI_ZNZLIB_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Simplify the cmake code by removing unnecessary variables
that had no value.  Simply used the source file list directly
rather than make a varible with the list.

Co-authored-by: leej3 <johnleenimh@gmail.com>