### PR TITLE
move clib_01_read_write.c out of fsliolib

### DIFF
--- a/fsliolib/examples/Makefile
+++ b/fsliolib/examples/Makefile
@@ -32,16 +32,13 @@ endif
 
 
 
-all:	fsl_api_driver clib_01_read_write
+all:	fsl_api_driver
 
 clean:
-	rm -f fsl_api_driver clib_01_read_write
+	rm -f fsl_api_driver
 
 fsl_api_driver:	fsl_api_driver.c ../lib/libfslio.a
 	$(CC) $(CFLAGS) -o fsl_api_driver fsl_api_driver.c $(FSLIO_INCS) $(NIFTI_INCS) $(ZNZ_INCS) $(FSLIO_LIBS) $(NIFTI_LIBS) $(ZNZ_LIBS)
-
-clib_01_read_write: clib_01_read_write.c
-	$(CC) $(CFLAGS) -o clib_01_read_write clib_01_read_write.c $(NIFTI_INCS) $(ZNZ_INCS) $(NIFTI_LIBS) $(ZNZ_LIBS)
 
 help:
 	@echo "all:      make the fsl_api_driver program"

--- a/real_easy/stand_alone_app/clib_01_read_write.c
+++ b/real_easy/stand_alone_app/clib_01_read_write.c
@@ -16,13 +16,13 @@
 int show_help( void )
 {
    printf(
-      "cib_01_read_write: short exmample of reading/writing NIfTI\n"
+      "clib_01_read_write: short exmample of reading/writing NIfTI\n"
       "\n"
       "    This program is to demonstrate how to read a NIfTI dataset,\n"
       "    set output filenames and write a NIfTI dataset, all via the\n"
       "    standard NIfTI C library.\n"
       "\n"
-      "    basic usage: cib_01_read_write -input FILE_IN -output FILE_OUT\n"
+      "    basic usage: clib_01_read_write -input FILE_IN -output FILE_OUT\n"
       "\n"
       "    options:     -help           : show this help\n"
       "                 -verb LEVEL     : the verbose level to LEVEL\n"


### PR DESCRIPTION
This does not actually depend on fslio.  In fact, it is not specific to nifti1 or nifti2, so I moved it to real_easy/stand_alone_app.