### PR TITLE
Adjust scan-build invocation to cause travis to fail on issues found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
         - WITH_COVERAGE="OFF"
         - WITH_MEMCHECK="OFF"
         - NIFTI_SHELL_SCRIPT_TESTS="ON"
-        - SCANBUILD_EXE="scan-build"
+        - SCANBUILD_EXE="scan-build -v --status-bugs"
         - CCC_CC=clang
         - CCC_CXX=clang++
     - compiler: clang


### PR DESCRIPTION
Make the scan-build invocation to return error if anything is found, so that travis tests don't pass if a PR introduces a new (possible) bug.