### PR TITLE
ENH: Add intent codes used by FSL to avoid future clashes

### DIFF
--- a/nifti2/nifti1.h
+++ b/nifti2/nifti1.h
@@ -957,6 +957,33 @@ typedef struct { unsigned char r,g,b; } rgb_byte ;
 
 #define NIFTI_INTENT_SHAPE        2005
 
+ /*! The following intent codes have been used by FSL FNIRT for
+     displacement/coefficient files.
+
+     These codes are included to prevent clashes in community-created
+     extensions to NIfTI. Encoding and decoding behavior for these
+     intents is not specified by the standard, and support is OPTIONAL
+     for conforming implementations.
+     */
+
+#define NIFTI_INTENT_FSL_FNIRT_DISPLACEMENT_FIELD       2006
+#define NIFTI_INTENT_FSL_CUBIC_SPLINE_COEFFICIENTS      2007
+#define NIFTI_INTENT_FSL_DCT_COEFFICIENTS               2008
+#define NIFTI_INTENT_FSL_QUADRATIC_SPLINE_COEFFICIENTS  2009
+
+ /*! The following intent codes have been used by FSL TOPUP for
+     displacement/coefficient files.
+
+     These codes are included to prevent clashes in community-created
+     extensions to NIfTI. Encoding and decoding behavior for these
+     intents is not specified by the standard, and support is OPTIONAL
+     for conforming implementations.
+     */
+
+#define NIFTI_INTENT_FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS        2016
+#define NIFTI_INTENT_FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS    2017
+#define NIFTI_INTENT_FSL_TOPUP_FIELD                            2018
+
 /* @} */
 
 /*---------------------------------------------------------------------------*/

--- a/niftilib/nifti1.h
+++ b/niftilib/nifti1.h
@@ -957,6 +957,33 @@ typedef struct { unsigned char r,g,b; } rgb_byte ;
 
 #define NIFTI_INTENT_SHAPE        2005
 
+ /*! The following intent codes have been used by FSL FNIRT for
+     displacement/coefficient files.
+
+     These codes are included to prevent clashes in community-created
+     extensions to NIfTI. Encoding and decoding behavior for these
+     intents is not specified by the standard, and support is OPTIONAL
+     for conforming implementations.
+     */
+
+#define NIFTI_INTENT_FSL_FNIRT_DISPLACEMENT_FIELD       2006
+#define NIFTI_INTENT_FSL_CUBIC_SPLINE_COEFFICIENTS      2007
+#define NIFTI_INTENT_FSL_DCT_COEFFICIENTS               2008
+#define NIFTI_INTENT_FSL_QUADRATIC_SPLINE_COEFFICIENTS  2009
+
+ /*! The following intent codes have been used by FSL TOPUP for
+     displacement/coefficient files.
+
+     These codes are included to prevent clashes in community-created
+     extensions to NIfTI. Encoding and decoding behavior for these
+     intents is not specified by the standard, and support is OPTIONAL
+     for conforming implementations.
+     */
+
+#define NIFTI_INTENT_FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS        2016
+#define NIFTI_INTENT_FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS    2017
+#define NIFTI_INTENT_FSL_TOPUP_FIELD                            2018
+
 /* @} */
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
These intent codes were present in the FSL 5.0.9 source code. I have not downloaded more recent versions to see if they have added new codes.

@pauldmccarthy I figure someone from the FSL world should probably have a look over this.

Closes #66.