### PR TITLE
Build "unused functions in nifticdf

### DIFF
--- a/nifticdf/CMakeLists.txt
+++ b/nifticdf/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(NIFTI_CDFLIB_NAME ${NIFTI_PACKAGE_PREFIX}nifticdf)
 
 add_library(${NIFTI_CDFLIB_NAME} nifticdf.c )
+target_compile_options(${NIFTI_CDFLIB_NAME} PRIVATE "-D__COMPILE_UNUSED_FUNCTIONS__")
 target_link_libraries(${NIFTI_CDFLIB_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}niftiio)
 target_include_directories(${NIFTI_CDFLIB_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/nifticdf/nifticdf.h
+++ b/nifticdf/nifticdf.h
@@ -120,7 +120,7 @@ double dbetrm(double*,double*);
 double devlpl(const double [],const int*,const double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
 double dexpm1(double*);
-double dinvnr(double *p,double *q);
+double dinvnr(const double *p,const double *q);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
 void E0000(int,int*,double*,double*,unsigned long*,
                   unsigned long*,const double*,const double*,const double*,


### PR DESCRIPTION
Removing these functions breaks the AFNI build.

The header declaration is slightly different from the definition in the .c