### PR TITLE
make test data download optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,11 @@ include(CTest)
 set_if_not_defined(NIFTI_BUILD_TESTING ${BUILD_TESTING})
 
 if (NIFTI_BUILD_TESTING )
+  option(
+    DOWNLOAD_TEST_DATA
+    "Allow download of data used for some tests. Can be used in conjunction with ctest label filter '-LE NEEDS_DATA'"
+    ON
+    )
   set_if_not_defined(NIFTI_SHELL_SCRIPT_TESTS "ON")
   if ( CMAKE_VERSION VERSION_LESS 3.11.0 )
     # CMAKE VERSION 3.11.0 needed for fetching data with cmake
@@ -125,11 +130,11 @@ if (NIFTI_BUILD_TESTING )
           URL_HASH SHA256=5dafec078151018da7aaf3c941bd31f246f590bc34fa3fef29ce77a773db16a6
           )
   FetchContent_GetProperties(fetch_testing_data)
+  if(DOWNLOAD_TEST_DATA)
   if(NOT fetch_testing_data)
     set(FETCHCONTENT_QUIET OFF)
-    message(STATUS "Downloading testing data... please wait")
     FetchContent_Populate( fetch_testing_data )
-    message(STATUS "download complete.")
+  endif()
   endif()
 endif()
 

--- a/nifti2/CMakeLists.txt
+++ b/nifti2/CMakeLists.txt
@@ -76,6 +76,12 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
   add_test( NAME ${TEST_PREFIX}_header_check COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_hdr -infiles ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data/anat0.nii )
   add_test( NAME ${TEST_PREFIX}_nim_check    COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_nim -infiles ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data/anat0.nii )
 
+  set_tests_properties(${TEST_PREFIX}_disp_hdr PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_disp_nim PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_disp_ext PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_header_check PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_nim_check PROPERTIES LABELS NEEDS_DATA)
+
   #The help screens always return 1; add_test( NAME ${NIFTI_PACKAGE_PREFIX}nifti1_tool1_help COMMAND $<TARGET_FILE:${TOOL_NAME}>)
   add_test( NAME ${TEST_PREFIX}_tool_n1  COMMAND $<TARGET_FILE:${TOOL_NAME}> -disp_hdr -infile ${CMAKE_CURRENT_BINARY_DIR}/n1 )
   add_test( NAME ${TEST_PREFIX}_tool_n2  COMMAND $<TARGET_FILE:${TOOL_NAME}> -disp_hdr -infile ${CMAKE_CURRENT_BINARY_DIR}/n2 )
@@ -97,6 +103,8 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
   #add_test( NAME ${TEST_PREFIX}_tool_rm_ext /bin/sh ${NIFTI_SOURCE_DIR}/niftilib/rmthenrun rm_ext.nii COMMAND $<TARGET_FILE:${TOOL_NAME}> -rm_ext ALL -prefix rm_ext.nii -infile ${CMAKE_CURRENT_BINARY_DIR}/zn1.nii.gz )
   add_test( NAME ${TEST_PREFIX}_tool_check_hdr COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_hdr -infile ${CMAKE_CURRENT_BINARY_DIR}/za2 )
   add_test( NAME ${TEST_PREFIX}_tool_check_nim COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_nim -infile ${CMAKE_CURRENT_BINARY_DIR}/za2 )
+  set_tests_properties(${TEST_PREFIX}_tool_check_hdr PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_tool_check_nim PROPERTIES LABELS NEEDS_DATA)
 
   #add_test( NAME ${TEST_PREFIX}_tool_copy_collapsed_image /bin/sh ${NIFTI_SOURCE_DIR}/niftilib/rmthenrun cci_zn1.nii COMMAND $<TARGET_FILE:${TOOL_NAME}> -cci 2 2 2 -1 -1 -1 -1 -prefix cci_zn1.nii -infile ${CMAKE_CURRENT_BINARY_DIR}/zn1.nii.gz )
 
@@ -117,6 +125,7 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
       message(STATUS "NiftiTestGeneratedFiles_${testsuffix}" )
     set_tests_properties( ${TEST_PREFIX}_tool_${testsuffix} ${TEST_PREFIX}_test_${testsuffix}
             PROPERTIES RESOURCE_LOCK Serial_${testsuffix}
+            LABELS NEEDS_DATA
             )
     set_tests_properties(cleanup_${testsuffix} PROPERTIES FIXTURES_CLEANUP  NiftiTestGeneratedFiles_${testsuffix} )
   endforeach()
@@ -135,22 +144,31 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
           ${TEST_PREFIX}_tool_copy_brick_list
           ${TEST_PREFIX}_tool_disp_ci ${TEST_PREFIX}_tool_disp_ts ${TEST_PREFIX}_tool_strip_extras
           PROPERTIES RESOURCE_LOCK Serial_zn1
+          LABELS NEEDS_DATA
           )
   #==END NIFTI1 and NIFTI2 common tests ============================================
 
   add_test( NAME ${TEST_PREFIX}_misc_tests COMMAND $<TARGET_FILE:${TOOL_NAME}> -run_misc_tests -debug 2 -infiles ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data/e4.60005.nii.gz )
+  set_tests_properties(${TEST_PREFIX}_misc_tests PROPERTIES LABELS NEEDS_DATA)
   if(UNIX AND NIFTI_SHELL_SCRIPT_TESTS) # unix needed to run shell scripts
       set(NIFTI_TEST_SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR}/nifti_regress_test/cmake_testscripts)
       add_test( NAME ${TEST_PREFIX}_modhdr_exts        COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/mod_header_test.sh    $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
       add_test( NAME ${TEST_PREFIX}_bricks_test        COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/bricks_test.sh        $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
+
+      set_tests_properties(${TEST_PREFIX}_modhdr_exts PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_bricks_test PROPERTIES LABELS NEEDS_DATA)
 
       add_test( NAME ${TEST_PREFIX}_dci_test           COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/dci_test.sh           $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
       add_test( NAME ${TEST_PREFIX}_comment_test       COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/comment_test.sh       $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
       add_test( NAME ${TEST_PREFIX}_dsets_test         COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/dsets_test.sh         $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
       add_test( NAME ${TEST_PREFIX}_newfiles_test      COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/newfiles_test.sh      $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
 
+      set_tests_properties(${TEST_PREFIX}_dci_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_comment_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_newfiles_test PROPERTIES LABELS NEEDS_DATA)
+
       add_test( NAME ${TEST_PREFIX}_dts_test            COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/dts_test.sh          $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
-      set_tests_properties( ${TEST_PREFIX}_dts_test PROPERTIES DEPENDS ${TEST_PREFIX}_bricks_test)
+      set_tests_properties( ${TEST_PREFIX}_dts_test PROPERTIES DEPENDS ${TEST_PREFIX}_bricks_test LABELS NEEDS_DATA)
 
       add_test( NAME ${TEST_PREFIX}_mod_hdr2_test       COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/mod_header_2_test.sh $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/CiftiLib_data )
       add_test( NAME ${TEST_PREFIX}_c21_a_info_test     COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/c21_a_info_test.sh   $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/CiftiLib_data )
@@ -158,6 +176,11 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
       add_test( NAME ${TEST_PREFIX}_c21_c_make_im_test  COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/c21_c_make_im.sh     $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/CiftiLib_data )
       add_test( NAME ${TEST_PREFIX}_c21_d_misc_tests    COMMAND sh ${NIFTI_TEST_SCRIPT_DIR}/c21_d_misc_tests.sh  $<TARGET_FILE:${TOOL_NAME}> ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data )
 
+      set_tests_properties(${TEST_PREFIX}_mod_hdr2_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_c21_a_info_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_c21_b_cifti_in_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_c21_c_make_im_test PROPERTIES LABELS NEEDS_DATA)
+      set_tests_properties(${TEST_PREFIX}_c21_d_misc_tests PROPERTIES LABELS NEEDS_DATA)
   endif()
   unset(TEST_SUFFIX)
   unset(TEST_PREFIX)

--- a/niftilib/CMakeLists.txt
+++ b/niftilib/CMakeLists.txt
@@ -84,6 +84,12 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
   add_test( NAME ${TEST_PREFIX}_header_check COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_hdr -infiles ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data/anat0.nii )
   add_test( NAME ${TEST_PREFIX}_nim_check    COMMAND $<TARGET_FILE:${TOOL_NAME}> -check_nim -infiles ${fetch_testing_data_SOURCE_DIR}/nifti_regress_data/anat0.nii )
 
+  set_tests_properties(${TEST_PREFIX}_disp_hdr PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_disp_nim PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_disp_ext PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_header_check PROPERTIES LABELS NEEDS_DATA)
+  set_tests_properties(${TEST_PREFIX}_nim_check PROPERTIES LABELS NEEDS_DATA)
+
   #The help screens always return 1; add_test( NAME ${NIFTI_PACKAGE_PREFIX}nifti1_tool1_help COMMAND $<TARGET_FILE:${TOOL_NAME}>)
   add_test( NAME ${TEST_PREFIX}_tool_n1  COMMAND $<TARGET_FILE:${TOOL_NAME}> -disp_hdr -infile ${CMAKE_CURRENT_BINARY_DIR}/n1 )
   add_test( NAME ${TEST_PREFIX}_tool_n2  COMMAND $<TARGET_FILE:${TOOL_NAME}> -disp_hdr -infile ${CMAKE_CURRENT_BINARY_DIR}/n2 )
@@ -125,6 +131,7 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
       message(STATUS "NiftiTestGeneratedFiles_${testsuffix}" )
     set_tests_properties( ${TEST_PREFIX}_tool_${testsuffix} ${TEST_PREFIX}_test_${testsuffix}
             PROPERTIES RESOURCE_LOCK Serial_${testsuffix}
+            LABELS NEEDS_DATA
             )
     set_tests_properties(cleanup_${testsuffix} PROPERTIES FIXTURES_CLEANUP  NiftiTestGeneratedFiles_${testsuffix} )
   endforeach()
@@ -135,14 +142,15 @@ if(NIFTI_BUILD_TESTING AND NIFTI_BUILD_APPLICATIONS)
   set_tests_properties( ${TEST_PREFIX}_tool_disp_ci          PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_zn1)
   set_tests_properties( ${TEST_PREFIX}_tool_disp_ts          PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_zn1)
   set_tests_properties( ${TEST_PREFIX}_tool_strip_extras     PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_zn1)
-  set_tests_properties( ${TEST_PREFIX}_tool_check_hdr        PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_za2)
-  set_tests_properties( ${TEST_PREFIX}_tool_check_nim        PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_za2)
+  set_tests_properties( ${TEST_PREFIX}_tool_check_hdr        PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_za2  LABELS NEEDS_DATA)
+  set_tests_properties( ${TEST_PREFIX}_tool_check_nim        PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFiles_za2  LABELS NEEDS_DATA)
   #set_tests_properties( ${TEST_PREFIX}_tool_copy_collapsed_image PROPERTIES FIXTURES_REQUIRED NiftiTestGeneratedFileszn1)
 
   set_tests_properties( ${TEST_PREFIX}_tool_diff_hdr ${TEST_PREFIX}_tool_diff_nims
           ${TEST_PREFIX}_tool_copy_brick_list
           ${TEST_PREFIX}_tool_disp_ci ${TEST_PREFIX}_tool_disp_ts ${TEST_PREFIX}_tool_strip_extras
           PROPERTIES RESOURCE_LOCK Serial_zn1
+          LABELS NEEDS_DATA
           )
   #==END NIFTI1 and NIFTI2 common tests ============================================
 


### PR DESCRIPTION
Requested by @yarikoptic for the purposes of debian packaging.
With this commit, when the cmake option DOWNLOAD_TEST_DATA is set to OFF,
the test data will not be fetched.
In conjunction the NEEDS_DATA label can be used to filter out dependent
tests i.e. ctest -LE NEEDS_DATA