### PR TITLE
Use ints for base version macros.  Add formatting.

### DIFF
--- a/cmake/nifti_macros.cmake
+++ b/cmake/nifti_macros.cmake
@@ -108,9 +108,8 @@ function(get_lib_version_vars version_header libver libver_major)
     # Function reads a file containing the lib version and sets the
     # approprioate variables in the parent scope
     file(READ ${version_header} VER_FILE)
-    string(REGEX MATCHALL "(_MAJOR|_MINOR|_PATCH) \"([0-9]*)\"" VER_MATCHES ${VER_FILE})
+    string(REGEX MATCHALL "(_MAJOR|_MINOR|_PATCH) ([0-9]*)" VER_MATCHES ${VER_FILE})
     string(REGEX REPLACE "(_MAJOR |_MINOR |_PATCH )" "" VER_MATCHES ${VER_MATCHES})
-    string(REGEX REPLACE "\"" "" VER_MATCHES ${VER_MATCHES})
     string(SUBSTRING ${VER_MATCHES} 0 1 LIB_MAJOR_VERSION )
     string(SUBSTRING ${VER_MATCHES} 1 1 LIB_MINOR_VERSION )
     string(SUBSTRING ${VER_MATCHES} 2 1 LIB_PATCH_VERSION )

--- a/cmake/nifti_macros.cmake
+++ b/cmake/nifti_macros.cmake
@@ -103,16 +103,20 @@ function(install_nifti_target target_name)
     endif()
 endfunction()
 
+function(get_lib_version_var ver_header_text ver_type version_out)
+  # Gets version for MAJOR/MINOR or PATCH from version header file
+  string(REGEX MATCH "_${ver_type} [0-9]*" MATCHED "${ver_header_text}")
+  string(REGEX REPLACE "_${ver_type} " "" OUTPUT "${MATCHED}")
+  set(${version_out} ${OUTPUT} PARENT_SCOPE)
+endfunction()
 
 function(get_lib_version_vars version_header libver libver_major)
     # Function reads a file containing the lib version and sets the
     # approprioate variables in the parent scope
     file(READ ${version_header} VER_FILE)
-    string(REGEX MATCHALL "(_MAJOR|_MINOR|_PATCH) ([0-9]*)" VER_MATCHES ${VER_FILE})
-    string(REGEX REPLACE "(_MAJOR |_MINOR |_PATCH )" "" VER_MATCHES ${VER_MATCHES})
-    string(SUBSTRING ${VER_MATCHES} 0 1 LIB_MAJOR_VERSION )
-    string(SUBSTRING ${VER_MATCHES} 1 1 LIB_MINOR_VERSION )
-    string(SUBSTRING ${VER_MATCHES} 2 1 LIB_PATCH_VERSION )
+    get_lib_version_var(${VER_FILE} "MAJOR" LIB_MAJOR_VERSION )
+    get_lib_version_var(${VER_FILE} "MINOR"  LIB_MINOR_VERSION )
+    get_lib_version_var(${VER_FILE} "PATCH"  LIB_PATCH_VERSION )
     set(LIB_VERSION "${LIB_MAJOR_VERSION}.${LIB_MINOR_VERSION}.${LIB_PATCH_VERSION}")
 
     # Check that a valid version has been specified (of the form XX.XX.XX)

--- a/nifti2/nifti2_io_version.h
+++ b/nifti2/nifti2_io_version.h
@@ -1,12 +1,15 @@
 /* NOTE:  When changing version consider the impact on versions in
   nifti2_io_version.h nifti1_io_version.h nifticdf_version.h and znzlib.h
 */
-#define NIFTI2_IO_VERSION_MAJOR "2"
-#define NIFTI2_IO_VERSION_MINOR "1"
-#define NIFTI2_IO_VERSION_PATCH "0"
+#define NIFTI2_IO_VERSION_MAJOR 2
+#define NIFTI2_IO_VERSION_MINOR 1
+#define NIFTI2_IO_VERSION_PATCH 0
+
+/* main string macros: NIFTI2_IO_VERSION and NIFTI2_IO_SOURCE_VERSION */
 #define NIFTI2_IO_VERSION_TO_STRING(x) NIFTI2_IO_VERSION_TO_STRING0(x)
 #define NIFTI2_IO_VERSION_TO_STRING0(x) #x
-#define NIFTI2_IO_VERSION                                                                                                    \
-  NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_MAJOR)                                                                             \
-  "." NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_MINOR) "." NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_PATCH)
+#define NIFTI2_IO_VERSION                                   \
+   NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_MAJOR)     \
+   "." NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_MINOR) \
+   "." NIFTI2_IO_VERSION_TO_STRING(NIFTI2_IO_VERSION_PATCH)
 #define NIFTI2_IO_SOURCE_VERSION "NIFTI2_IO version " NIFTI2_IO_VERSION

--- a/nifticdf/nifticdf_version.h
+++ b/nifticdf/nifticdf_version.h
@@ -1,12 +1,16 @@
 /* NOTE:  When changing version consider the impact on versions in
   nifti2_io_version.h nifti1_io_version.h nifticdf_version.h and znzlib.h
 */
-#define NIFTICDF_VERSION_MAJOR "2"
-#define NIFTICDF_VERSION_MINOR "1"
-#define NIFTICDF_VERSION_PATCH "0"
+#define NIFTICDF_VERSION_MAJOR 2
+#define NIFTICDF_VERSION_MINOR 1
+#define NIFTICDF_VERSION_PATCH 0
+
+/* main string macros: NIFTICDF_VERSION and NIFTICDF_SOURCE_VERSION */
 #define NIFTICDF_VERSION_TO_STRING(x) NIFTICDF_VERSION_TO_STRING0(x)
 #define NIFTICDF_VERSION_TO_STRING0(x) #x
-#define NIFTICDF_VERSION                                                                                                    \
-  NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_MAJOR)                                                                             \
-  "." NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_MINOR) "." NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_PATCH)
+#define NIFTICDF_VERSION                                 \
+  NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_MAJOR)     \
+  "." NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_MINOR) \
+  "." NIFTICDF_VERSION_TO_STRING(NIFTICDF_VERSION_PATCH)
+
 #define NIFTICDF_SOURCE_VERSION "NIFTICDF version " NIFTICDF_VERSION

--- a/niftilib/nifti1_io_version.h
+++ b/niftilib/nifti1_io_version.h
@@ -1,12 +1,16 @@
 /* NOTE:  When changing version consider the impact on versions in
   nifti2_io_version.h nifti1_io_version.h nifticdf_version.h and znzlib.h
 */
-#define NIFTI1_IO_VERSION_MAJOR "2"
-#define NIFTI1_IO_VERSION_MINOR "1"
-#define NIFTI1_IO_VERSION_PATCH "0"
+#define NIFTI1_IO_VERSION_MAJOR 2
+#define NIFTI1_IO_VERSION_MINOR 1
+#define NIFTI1_IO_VERSION_PATCH 0
+
+/* main string macros: NIFTI1_IO_VERSION and NIFTI1_IO_SOURCE_VERSION */
 #define NIFTI1_IO_VERSION_TO_STRING(x) NIFTI1_IO_VERSION_TO_STRING0(x)
 #define NIFTI1_IO_VERSION_TO_STRING0(x) #x
-#define NIFTI1_IO_VERSION                                                                                                    \
-  NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_MAJOR)                                                                             \
-  "." NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_MINOR) "." NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_PATCH)
+#define NIFTI1_IO_VERSION                                   \
+   NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_MAJOR)     \
+   "." NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_MINOR) \
+   "." NIFTI1_IO_VERSION_TO_STRING(NIFTI1_IO_VERSION_PATCH)
+
 #define NIFTI1_IO_SOURCE_VERSION "NIFTI1_IO version " NIFTI1_IO_VERSION

--- a/znzlib/znzlib_version.h
+++ b/znzlib/znzlib_version.h
@@ -1,12 +1,16 @@
 /* NOTE:  When changing version consider the impact on versions in
   nifti2_io_version.h nifti1_io_version.h nifticdf_version.h and znzlib.h
 */
-#define ZNZLIB_VERSION_MAJOR "3"
-#define ZNZLIB_VERSION_MINOR "0"
-#define ZNZLIB_VERSION_PATCH "0"
+#define ZNZLIB_VERSION_MAJOR 3
+#define ZNZLIB_VERSION_MINOR 0
+#define ZNZLIB_VERSION_PATCH 0
+
+/* main string macros: ZNZLIB_VERSION and ZNZLIB_SOURCE_VERSION */
 #define ZNZLIB_VERSION_TO_STRING(x) ZNZLIB_VERSION_TO_STRING0(x)
 #define ZNZLIB_VERSION_TO_STRING0(x) #x
-#define ZNZLIB_VERSION                                                                                                    \
-  ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_MAJOR)                                                                             \
-  "." ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_MINOR) "." ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_PATCH)
+#define ZNZLIB_VERSION                               \
+  ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_MAJOR)     \
+  "." ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_MINOR) \
+  "." ZNZLIB_VERSION_TO_STRING(ZNZLIB_VERSION_PATCH)
+
 #define ZNZLIB_SOURCE_VERSION "znz version " ZNZLIB_VERSION


### PR DESCRIPTION
@leej3 @hjmjohnson I believe this is what we wanted for the base macros, as ints (with added formatting).