### PR TITLE
improve parent project demo

### DIFF
--- a/real_easy/parent_project_demo/CMakeLists.txt
+++ b/real_easy/parent_project_demo/CMakeLists.txt
@@ -98,7 +98,7 @@ include(FetchContent)
 # make a new release, and then update the URL and hash (shasum -a 256 <downloaded tarball>).
 FetchContent_Declare( fetch_nifti_clib_git_repo
         GIT_REPOSITORY https://github.com/NIFTI-Imaging/nifti_clib.git
-        GIT_TAG        phase1-update-for-external-inclusion # or v3.0.0, or <HASH>
+        GIT_TAG        master # or v3.0.0, or <HASH>
         SOURCE_DIR     ${CMAKE_CURRENT_LIST_DIR}/nifti_clib_download # <- not standard,  remove this line to download in binary tree
         )
 FetchContent_GetProperties(fetch_nifti_clib_git_repo)

--- a/real_easy/parent_project_demo/cmake/SILLYDEMOConfig.cmake
+++ b/real_easy/parent_project_demo/cmake/SILLYDEMOConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/SILLYDEMOTargets.cmake")


### PR DESCRIPTION
Master now works with example pattern of driving the nifti build
so use that for the fetch content example

Add a simple config file for demo of exporting config/targets etc.