### PR TITLE
do not build man pages by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 #message(STATUS "---------------------ZLIB -${NIFTI_ZLIB_LIBRARIES}--")
 add_definitions(-DHAVE_ZLIB)
 
-set_if_not_defined(NIFTI_INSTALL_NO_DOCS FALSE)
+set_if_not_defined(NIFTI_INSTALL_NO_DOCS TRUE)
 
 # Include test to verify linking in installed executables
 # The test should only be added when applications are built, and no prefix string is set.


### PR DESCRIPTION
Man page generation depends on help2man. If needed use something like:

cmake -DNIFTI_INSTALL_NO_DOCS=FALSE /path/to/src/dir