### PR TITLE
Resolution for NIfTI-2 file output issues

### DIFF
--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -7512,8 +7512,8 @@ int nifti_convert_nim2n2hdr(const nifti_image * nim, nifti_2_header * hdr)
    /**- load the ANALYZE-7.5 generic parts of the header struct */
 
    nhdr.sizeof_hdr = sizeof(nhdr) ;
-   if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 ) strcpy(nhdr.magic,"n+2") ;
-   else                                          strcpy(nhdr.magic,"ni2") ;
+   memcpy(nhdr.magic, nifti2_magic, 8);
+   if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_2 ) nhdr.magic[1] = 'i';
 
    nhdr.datatype = nim->datatype ;
    nhdr.bitpix   = 8 * nim->nbyper ;

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -4379,7 +4379,7 @@ int nifti_set_type_from_names( nifti_image * nim )
    } else {
       /* not too picky here, do what must be done, and then verify */
       if( strcmp(nim->fname, nim->iname) == 0 )          /* one file, type 1 */
-         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_ASCII) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
+         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_NIFTI2_1) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ) /* cannot be type 1 */
          nim->nifti_type = NIFTI_FTYPE_NIFTI1_2;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 )

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -8214,6 +8214,8 @@ char *nifti_image_to_ascii( const nifti_image *nim )
               (nim->nifti_type == NIFTI_FTYPE_NIFTI1_1) ? "NIFTI-1+"
              :(nim->nifti_type == NIFTI_FTYPE_NIFTI1_2) ? "NIFTI-1"
              :(nim->nifti_type == NIFTI_FTYPE_ASCII   ) ? "NIFTI-1A"
+             :(nim->nifti_type == NIFTI_FTYPE_NIFTI2_1) ? "NIFTI-2+"
+             :(nim->nifti_type == NIFTI_FTYPE_NIFTI2_2) ? "NIFTI-2"
              :                         "ANALYZE-7.5" ) ;
 
    /** Strings that we don't control (filenames, etc.) that might
@@ -8561,6 +8563,10 @@ nifti_image *nifti_image_from_ascii( const char *str, int * bytes_read )
                nim->nifti_type = NIFTI_FTYPE_NIFTI1_2 ;
        else if( strcmp(rhs,"NIFTI-1A")    == 0 )
                nim->nifti_type = NIFTI_FTYPE_ASCII ;
+       else if( strcmp(rhs,"NIFTI-2+")    == 0 )
+               nim->nifti_type = NIFTI_FTYPE_NIFTI2_1 ;
+       else if( strcmp(rhs,"NIFTI-2")     == 0 )
+               nim->nifti_type = NIFTI_FTYPE_NIFTI2_2 ;
      }
      else if( strcmp(lhs,"header_filename") == 0 ){
        nim->fname = nifti_strdup(rhs) ;

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -3825,6 +3825,7 @@ char * nifti_findimgname(const char* fname , int nifti_type)
       /* if we get 3 or more extensions, can make a loop here... */
 
       if (nifti_type == NIFTI_FTYPE_NIFTI1_1) first = 0; /* should match .nii */
+      else if (nifti_type == NIFTI_FTYPE_NIFTI2_1) first = 0;
       else                                    first = 1; /* should match .img */
 
       strcpy(imgname,basename);
@@ -3906,6 +3907,7 @@ char * nifti_makehdrname(const char * prefix, int nifti_type, int check,
    }
    /* otherwise, make one up */
    else if( nifti_type == NIFTI_FTYPE_NIFTI1_1 ) strcat(iname, extnii);
+   else if( nifti_type == NIFTI_FTYPE_NIFTI2_1 ) strcat(iname, extnii);
    else if( nifti_type == NIFTI_FTYPE_ASCII )    strcat(iname, extnia);
    else                                          strcat(iname, exthdr);
 
@@ -3980,6 +3982,7 @@ char * nifti_makeimgname(const char * prefix, int nifti_type, int check,
    }
    /* otherwise, make one up */
    else if( nifti_type == NIFTI_FTYPE_NIFTI1_1 ) strcat(iname, extnii);
+   else if( nifti_type == NIFTI_FTYPE_NIFTI2_1 ) strcat(iname, extnii);
    else if( nifti_type == NIFTI_FTYPE_ASCII )    strcat(iname, extnia);
    else                                          strcat(iname, extimg);
 
@@ -4118,7 +4121,8 @@ int nifti_type_and_names_match( nifti_image * nim, int show_warn )
    if( errs ) return 0;   /* do not proceed, but this is just a mis-match */
 
    /* general tests */
-   if( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ){  /* .nii */
+   if( (nim->nifti_type == NIFTI_FTYPE_NIFTI1_1) ||
+       (nim->nifti_type == NIFTI_FTYPE_NIFTI2_1) ){  /* .nii */
       if( fileext_n_compare(ext_h,".nii",4) ) {
          if( show_warn )
             fprintf(stderr,
@@ -4142,6 +4146,7 @@ int nifti_type_and_names_match( nifti_image * nim, int show_warn )
       }
    }
    else if( (nim->nifti_type == NIFTI_FTYPE_NIFTI1_2) || /* .hdr/.img */
+            (nim->nifti_type == NIFTI_FTYPE_NIFTI2_2) ||
             (nim->nifti_type == NIFTI_FTYPE_ANALYZE) )
    {
       if( fileext_n_compare(ext_h,".hdr",4) != 0 ){
@@ -4374,9 +4379,11 @@ int nifti_set_type_from_names( nifti_image * nim )
    } else {
       /* not too picky here, do what must be done, and then verify */
       if( strcmp(nim->fname, nim->iname) == 0 )          /* one file, type 1 */
-         nim->nifti_type = NIFTI_FTYPE_NIFTI1_1;
+         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_NIFTI2_1) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ) /* cannot be type 1 */
          nim->nifti_type = NIFTI_FTYPE_NIFTI1_2;
+      else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 )
+         nim->nifti_type = NIFTI_FTYPE_NIFTI2_2;
    }
 
    if( g_opts.debug > 2 ) fprintf(stderr," -> %d\n",nim->nifti_type);
@@ -5005,7 +5012,7 @@ nifti_image* nifti_convert_n2hdr2nim(nifti_2_header nhdr, const char * fname)
 
    is_onefile = (ni_ver > 0) && NIFTI_ONEFILE(nhdr) ;
 
-   nim->nifti_type = (is_onefile) ? NIFTI_FTYPE_NIFTI1_1 : NIFTI_FTYPE_NIFTI1_2;
+   nim->nifti_type = (is_onefile) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI2_2;
 
    ii = nifti_short_order() ;
    if( doswap )   nim->byteorder = REVERSE_ORDER(ii) ;
@@ -7717,6 +7724,7 @@ void nifti_set_iname_offset(nifti_image *nim, int nifti_ver)
 
      /* NIFTI-1 single binary file - always update */
      case NIFTI_FTYPE_NIFTI1_1:
+     case NIFTI_FTYPE_NIFTI2_1:
        offset = nifti_extension_size(nim) + hsize + 4;
        /* be sure offset is aligned to a 16 byte boundary */
        if ( ( offset % 16 ) != 0 )  offset = ((offset + 0xf) & ~0xf);
@@ -7832,7 +7840,7 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    }
 
    /* if writing to 2 files, make sure iname is set and different from fname */
-   if( nim->nifti_type != NIFTI_FTYPE_NIFTI1_1 ){
+   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) && (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){
        if( nim->iname && strcmp(nim->iname,nim->fname) == 0 ){
          free(nim->iname) ; nim->iname = NULL ;
        }
@@ -7843,7 +7851,7 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    }
 
    /* if we have an imgfile and will write the header there, use it */
-   if( ! znz_isnull(imgfile) && nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ){
+   if( ! znz_isnull(imgfile) && (nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 || nim->nifti_type == NIFTI_FTYPE_NIFTI2_1) ){
       if( g_opts.debug > 2 ) fprintf(stderr,"+d using passed file for hdr\n");
       fp = imgfile;
    }
@@ -7877,7 +7885,7 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
       znzclose(fp); return(fp);
    }
 
-   if( nim->nifti_type != NIFTI_FTYPE_NIFTI1_1 ){ /* get a new file pointer */
+   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) && (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){ /* get a new file pointer */
       znzclose(fp);         /* first, close header file */
       if( ! znz_isnull(imgfile) ){
          if(g_opts.debug > 2) fprintf(stderr,"+d using passed file for img\n");

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -4379,7 +4379,7 @@ int nifti_set_type_from_names( nifti_image * nim )
    } else {
       /* not too picky here, do what must be done, and then verify */
       if( strcmp(nim->fname, nim->iname) == 0 )          /* one file, type 1 */
-         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_NIFTI2_1) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
+         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_ASCII) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ) /* cannot be type 1 */
          nim->nifti_type = NIFTI_FTYPE_NIFTI1_2;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 )

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -4378,8 +4378,10 @@ int nifti_set_type_from_names( nifti_image * nim )
       nim->nifti_type = NIFTI_FTYPE_ASCII;
    } else {
       /* not too picky here, do what must be done, and then verify */
-      if( strcmp(nim->fname, nim->iname) == 0 )          /* one file, type 1 */
-         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_NIFTI2_1) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
+      if( strcmp(nim->fname, nim->iname) == 0 ) {        /* one file, type 1 */
+         nim->nifti_type = (nim->nifti_type >= NIFTI_FTYPE_NIFTI2_1) ?
+                              NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI1_1;
+      }
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ) /* cannot be type 1 */
          nim->nifti_type = NIFTI_FTYPE_NIFTI1_2;
       else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 )
@@ -7824,7 +7826,8 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
 
    if( nim->nifti_type == NIFTI_FTYPE_ASCII )   /* non-standard case */
       return nifti_write_ascii_image(nim,NBL,opts,write_data,leave_open);
-   else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 || nim->nifti_type == NIFTI_FTYPE_NIFTI2_2 ) {
+   else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 ||
+            nim->nifti_type == NIFTI_FTYPE_NIFTI2_2 ) {
       nifti_set_iname_offset(nim, 2);
       if( nifti_convert_nim2n2hdr(nim, &n2hdr) ) return NULL;
       nver = 2; /* we will write NIFTI-2 */
@@ -7836,7 +7839,8 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    }
 
    /* if writing to 2 files, make sure iname is set and different from fname */
-   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) && (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){
+   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) &&
+       (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){
        if( nim->iname && strcmp(nim->iname,nim->fname) == 0 ){
          free(nim->iname) ; nim->iname = NULL ;
        }
@@ -7847,7 +7851,8 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    }
 
    /* if we have an imgfile and will write the header there, use it */
-   if( ! znz_isnull(imgfile) && (nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 || nim->nifti_type == NIFTI_FTYPE_NIFTI2_1) ){
+   if( ! znz_isnull(imgfile) && (nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ||
+                                 nim->nifti_type == NIFTI_FTYPE_NIFTI2_1) ){
       if( g_opts.debug > 2 ) fprintf(stderr,"+d using passed file for hdr\n");
       fp = imgfile;
    }
@@ -7881,7 +7886,8 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
       znzclose(fp); return(fp);
    }
 
-   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) && (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){ /* get a new file pointer */
+   if( (nim->nifti_type != NIFTI_FTYPE_NIFTI1_1) &&
+       (nim->nifti_type != NIFTI_FTYPE_NIFTI2_1) ){ /* get a new file pointer */
       znzclose(fp);         /* first, close header file */
       if( ! znz_isnull(imgfile) ){
          if(g_opts.debug > 2) fprintf(stderr,"+d using passed file for img\n");

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -7815,8 +7815,6 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    if( write_data && NBL && ! nifti_NBL_matches_nim(nim, NBL) )
       ERREX("NBL does not match nim");
 
-   nifti_set_iname_offset(nim, 1);
-
    if( g_opts.debug > 1 ){
       fprintf(stderr,"-d writing nifti file '%s'...\n", nim->fname);
       if( g_opts.debug > 2 )
@@ -7826,17 +7824,15 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
 
    if( nim->nifti_type == NIFTI_FTYPE_ASCII )   /* non-standard case */
       return nifti_write_ascii_image(nim,NBL,opts,write_data,leave_open);
-
-   /* create the nifti header struct                  5 Aug, 2015 [rickr]
-        - default is NIFTI-1 (option?)
-        - if that fails try NIFTI-2
-   */
-   if( nifti_convert_nim2n1hdr(nim, &n1hdr) ) {
+   else if( nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 || nim->nifti_type == NIFTI_FTYPE_NIFTI2_2 ) {
       nifti_set_iname_offset(nim, 2);
       if( nifti_convert_nim2n2hdr(nim, &n2hdr) ) return NULL;
-      fprintf(stderr,"+d writing %s as NIFTI-2, instead...\n", nim->fname);
       nver = 2; /* we will write NIFTI-2 */
       hsize = (int)sizeof(nifti_2_header);
+   }
+   else {
+      nifti_set_iname_offset(nim, 1);
+      if( nifti_convert_nim2n1hdr(nim, &n1hdr) ) return NULL;
    }
 
    /* if writing to 2 files, make sure iname is set and different from fname */


### PR DESCRIPTION
Good morning. Unless I have significantly misunderstood something (in which case I apologise), there are a number of issues with the code in `nifti2_io.c` for creating NIfTI-2 format output. This PR addresses these issues with fairly minimal modifications, enough for me to be able to successfully produce a valid-looking NIfTI-2 file in my testing. The specific problems and changes are as follows.

- In several places the logic assumes that `NIFTI_FTYPE_NIFTI1_1` is the only `nifti_type` code that corresponds to a single-file format. This is resolved by also allowing for `NIFTI_FTYPE_NIFTI2_1`.
- The write logic in `nifti_image_write_hdr_img2()` previously defaulted to writing NIfTI-1, irrespective of the `nifti_type` code in the image (although ANALYZE format would be used if requested). Since `nifti_convert_nim2n1hdr()` would succeed for any valid image, NIfTI-2 format would essentially never be used. I have resolved this by using the `nifti_type` code to determine which format to prefer.
- `nifti_convert_nim2n2hdr()` created an incomplete magic number, resulting in an invalid NIfTI-2 header. This has been resolved by copying in the full magic number, and then tweaking it for the two-file format where needed.
- For completion, the functions converting to/from NIfTI-ASCII format now also specify NIfTI-2 where indicated by the `nifti_type` code.