### PR TITLE
Inconsistent definition of NIfTI-1 image struct

### DIFF
--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -227,7 +227,7 @@ typedef struct {
   int nv ;                      /*!< dimensions of grid array             */
   int nw ;                      /*!< dimensions of grid array             */
   int dim[8] ;                  /*!< dim[0]=ndim, dim[1]=nx, etc.         */
-  int64_t nvox ;                /*!< number of voxels = nx*ny*nz*...*nw   */
+  size_t nvox ;                 /*!< number of voxels = nx*ny*nz*...*nw   */
   int nbyper ;                  /*!< bytes per voxel, matches datatype    */
   int datatype ;                /*!< type of data in voxels: DT_* code    */
 


### PR DESCRIPTION
In the NIfTI-1 library, and specifically in `nifti1_io.h`, the `nifti_image` struct has an `nvox` member of type `size_t`. By contrast, in `nifti2_io.h`, the definition of the `nifti1_image` struct switches the type to `int64_t`. However, these two types are not equivalent. `size_t` is always an _unsigned_ type – although it is unlikely that the sign bit would become relevant for any real-world image. More problematic in practice is that `sizeof(size_t)` is 4 (rather than 8) on some platforms, so the redefinition will change the width of the type, leading to an unnecessary binary incompatibility with objects created using the NIfTI-1 library. This leads to a segfault in a wrapper library of mine that provides access to both versions of the NIfTI library.

This fairly trivial PR therefore changes the definition back, to use `size_t`.