### PR TITLE
Optional file behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 option( BUILD_SHARED_LIBS "Toggle building shared libraries." OFF)
 
 # add option to mimic FSL
-option( FSL "FSL name conflicts (img.nii and img.nii.gz), PIGZ support, reject complex images." OFF)
+option( FSLSTYLE "FSL name conflicts (img.nii and img.nii.gz), PIGZ support, reject complex images." OFF)
 
 # Include executables as part of the build
 option(NIFTI_BUILD_APPLICATIONS "Build various utility tools" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ endif()
 # current build behavior
 option( BUILD_SHARED_LIBS "Toggle building shared libraries." OFF)
 
+# add option to mimic FSL
+option( FSL "FSL name conflicts (img.nii and img.nii.gz), PIGZ support, reject complex images." OFF)
+
 # Include executables as part of the build
 option(NIFTI_BUILD_APPLICATIONS "Build various utility tools" ON)
 mark_as_advanced(NIFTI_BUILD_APPLICATIONS)

--- a/nifti2/CMakeLists.txt
+++ b/nifti2/CMakeLists.txt
@@ -20,6 +20,12 @@ if(BUILD_SHARED_LIBS)
 endif()
 install_nifti_target(${NIFTI_NIFTILIB2_NAME})
 
+if(FSLSTYLE)
+  ADD_DEFINITIONS(-DFSLSTYLE)
+  ADD_DEFINITIONS(-DREJECT_COMPLEX)
+  ADD_DEFINITIONS(-DPIGZ)
+endif()
+
 if(NIFTI_BUILD_APPLICATIONS)
   set(NIFTI_TOOL ${NIFTI_PACKAGE_PREFIX}nifti_tool)
   add_nifti_executable(${NIFTI_TOOL} nifti_tool.c)

--- a/nifti2/Makefile
+++ b/nifti2/Makefile
@@ -10,8 +10,8 @@ IFLAGS          = -I. -I../niftilib -I../znzlib
 CFLAGS          = -Wall -std=gnu99 -pedantic $(USEZLIB) $(IFLAGS)
 
 
-#run "FSL=1 make" for JPEGLS build
-ifeq "$(FSL)" "1"
+#run "FSLSTYLE=1 make" for JPEGLS build
+ifeq "$(FSLSTYLE)" "1"
 	CFLAGS += -DFSLSTYLE -DPIGZ -DREJECT_COMPLEX
 endif
 

--- a/nifti2/Makefile
+++ b/nifti2/Makefile
@@ -9,6 +9,12 @@ CC		= gcc
 IFLAGS          = -I. -I../niftilib -I../znzlib
 CFLAGS          = -Wall -std=gnu99 -pedantic $(USEZLIB) $(IFLAGS)
 
+
+#run "FSL=1 make" for JPEGLS build
+ifeq "$(FSL)" "1"
+	CFLAGS += -DFSLSTYLE -DPIGZ -DREJECT_COMPLEX
+endif
+
 LLIBS 		= -lz -lm
 
 MISC_OBJS	= nifticdf.o znzlib.o

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -1,5 +1,12 @@
 #define _NIFTI2_IO_C_
 
+//FSLSTYLE: generate error if both img.nii and img.nii.gz exists
+#define FSLSTYLE 
+//PIGZ: Use PIGZ parallel compression if environment includes "AFNI_COMPRESSOR=PIGZ"
+#define PIGZ
+//REJECT_COMPLEX: generate error if file is complex datatype
+// #define REJECT_COMPLEX
+
 #include "nifti2_io.h"   /* typedefs, prototypes, macros, etc. */
 #include "nifti2_io_version.h"
 
@@ -3741,7 +3748,22 @@ char * nifti_findhdrname(const char* fname)
 
    strcpy(hdrname,basename);
    strcat(hdrname,elist[efirst]);
+   #ifdef FSLSTYLE
+   if (nifti_fileexists(hdrname)) {
+      free(basename);
+      char *gzname =nifti_strdup(hdrname);
+      strcat(gzname,extzip);
+      if (nifti_fileexists(gzname)) {
+         fprintf(stderr,"Image Exception : Multiple possible filenames detected for basename (*.nii, *.nii.gz): %s\n", basename);
+         free(gzname);
+         exit(13);
+      }
+      free(gzname);
+      return hdrname; 
+   }
+   #else
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
+   #endif
 #ifdef HAVE_ZLIB
    strcat(hdrname,extzip);
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
@@ -5938,6 +5960,13 @@ nifti_image *nifti_image_read( const char *hname , int read_data )
       znzclose(fp);  free(hfile);  return NULL;
    }
 
+   #ifdef REJECT_COMPLEX
+   if ((nim->datatype == DT_COMPLEX64) || (nim->datatype == DT_COMPLEX128) || (nim->datatype == DT_COMPLEX256)) {
+      fprintf(stderr,"Image Exception Unsupported datatype (COMPLEX64): use fslcomplex to manipulate: %s\n", hname);
+      exit(13);
+    }
+    #endif
+
    if( nim == NULL ){
       znzclose( fp ) ;                                   /* close the file */
       if( g_opts.debug > 0 )
@@ -7454,6 +7483,10 @@ int nifti_convert_nim2n1hdr(const nifti_image * nim, nifti_1_header * hdr)
        nhdr.qoffset_z  = nim->qoffset_z ;
        nhdr.pixdim[0]  = (nim->qfac >= 0.0) ? 1.0f : -1.0f ;
      }
+     #ifdef FSLSTYLE
+     else //this helps for regression testing between this library and fsl, there is no other purpose. Without this you get false alarms
+       nhdr.pixdim[0]  = 1.0; //default if unknown and not needed
+     #endif
 
      if( nim->sform_code > 0 ){
        nhdr.sform_code = nim->sform_code ;
@@ -7565,6 +7598,10 @@ int nifti_convert_nim2n2hdr(const nifti_image * nim, nifti_2_header * hdr)
      nhdr.qoffset_z  = nim->qoffset_z ;
      nhdr.pixdim[0]  = (nim->qfac >= 0.0) ? 1.0f : -1.0f ;
    }
+   #ifdef FSLSTYLE
+   else //this helps for regression testing between this library and fsl, there is no other purpose. Without this you get false alarms
+     nhdr.pixdim[0]  = 1.0; //default if unknown and not needed
+   #endif
 
    if( nim->sform_code > 0 ){
      nhdr.sform_code = nim->sform_code ;
@@ -7770,6 +7807,73 @@ znzFile nifti_image_write_hdr_img( nifti_image *nim , int write_data ,
  do{ fprintf(stderr,"** ERROR: nifti_image_write_hdr_img: %s\n",(msg)) ;  \
      return fp ; } while(0)
 
+#ifdef PIGZ
+#ifdef HAVE_ZLIB
+int doPigz2(nifti_image *nim, struct nifti_2_header nhdr, const nifti_brick_list * NBL) {
+	FILE *pigzPipe;
+	char command[768];
+    strcpy(command, "pigz" );
+    strcat(command, " -n -f > \"");
+    strcat(command, nim->fname);
+    strcat(command, "\"");
+	#ifdef _MSC_VER
+	if (( pigzPipe = _popen(command, "w")) == NULL)
+		return -1;
+	#else
+	if (( pigzPipe = popen(command, "w")) == NULL)
+		return -1;
+	#endif
+	znzFile fp;
+	fp = (znzFile) calloc(1,sizeof(struct znzptr));
+	fp->zfptr = NULL;
+	fp->withz = 0;
+    fp->nzfptr = pigzPipe;
+	fwrite(&nhdr, sizeof(nhdr), 1, pigzPipe);
+	if( nim->nifti_type != NIFTI_FTYPE_ANALYZE )
+    nifti_write_extensions(fp,nim);
+	nifti_write_all_data(fp,nim,NBL);
+	#ifdef _MSC_VER
+	_pclose(pigzPipe);
+	#else
+	pclose(pigzPipe);
+	#endif
+	free(fp);
+	return 0;
+}
+
+int doPigz(nifti_image *nim, struct nifti_1_header nhdr, const nifti_brick_list * NBL) {
+	FILE *pigzPipe;
+	char command[768];
+    strcpy(command, "pigz" );
+    strcat(command, " -n -f > \"");
+    strcat(command, nim->fname);
+    strcat(command, "\"");
+	#ifdef _MSC_VER
+	if (( pigzPipe = _popen(command, "w")) == NULL)
+		return -1;
+	#else
+	if (( pigzPipe = popen(command, "w")) == NULL)
+		return -1;
+	#endif
+	znzFile fp;
+	fp = (znzFile) calloc(1,sizeof(struct znzptr));
+	fp->zfptr = NULL;
+	fp->withz = 0;
+    fp->nzfptr = pigzPipe;
+	fwrite(&nhdr, sizeof(nhdr), 1, pigzPipe);
+	if( nim->nifti_type != NIFTI_FTYPE_ANALYZE )
+    nifti_write_extensions(fp,nim);
+	nifti_write_all_data(fp,nim,NBL);
+	#ifdef _MSC_VER
+	_pclose(pigzPipe);
+	#else
+	pclose(pigzPipe);
+	#endif
+	free(fp);
+	return 0;
+}
+#endif //HAVE_ZLIB
+#endif //PIGZ
 
 /* ----------------------------------------------------------------------*/
 /*! This writes the header (and optionally the image data) to file
@@ -7859,6 +7963,28 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
    else {
       if( g_opts.debug > 2 )
          fprintf(stderr,"+d opening output file %s [%s]\n",nim->fname,opts);
+
+      #ifdef PIGZ
+      #ifdef HAVE_ZLIB
+      if ((( nim->nifti_type == NIFTI_FTYPE_NIFTI1_1 ) || (nim->nifti_type == NIFTI_FTYPE_NIFTI2_1 )) && (nifti_is_gzfile(nim->fname))  && (!leave_open) && (write_data) ) {
+        const char *key = "AFNI_COMPRESSOR";
+        char *value;
+        value = getenv(key);
+        //export AFNI_COMPRESSOR=PIGZ
+        char pigzKey[5] = "PIGZ";
+        if ((value != NULL) && (strstr(value,pigzKey))) {
+          if( nver == 2 ) {
+            if (doPigz2(nim, n2hdr, NBL) == 0)
+              return NULL;
+            } else {
+              if (doPigz(nim, n1hdr, NBL) == 0) //success writing with pigz
+                return NULL;
+            }
+        }
+      }
+      #endif //HAVE_ZLIB
+      #endif //PIGZ
+
       fp = znzopen( nim->fname , opts , nifti_is_gzfile(nim->fname) ) ;
       if( znz_isnull(fp) ){
          LNI_FERR(func,"cannot open output file",nim->fname);

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -1,9 +1,9 @@
 #define _NIFTI2_IO_C_
 
 //FSLSTYLE: generate error if both img.nii and img.nii.gz exists
-#define FSLSTYLE 
+// #define FSLSTYLE 
 //PIGZ: Use PIGZ parallel compression if environment includes "AFNI_COMPRESSOR=PIGZ"
-#define PIGZ
+// #define PIGZ
 //REJECT_COMPLEX: generate error if file is complex datatype
 // #define REJECT_COMPLEX
 

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -3698,10 +3698,8 @@ char * nifti_findhdrname(const char* fname)
    char  extzip[4]   = ".gz";
    int   efirst = 1;    /* init to .nii extension */
    int   eisupper = 0;  /* init to lowercase extensions */
-
    /**- check input file(s) for sanity */
    if( !nifti_validfilename(fname) ) return NULL;
-
    basename = nifti_makebasename(fname);
    if( !basename ) return NULL;   /* only on string alloc failure */
 
@@ -3751,12 +3749,13 @@ char * nifti_findhdrname(const char* fname)
    #ifdef FSLSTYLE
    if (nifti_fileexists(hdrname)) {
       free(basename);
-      char *gzname =nifti_strdup(hdrname);
+      char *gzname = (char *)calloc(sizeof(char),strlen(hdrname)+8);
+      strcpy(gzname, hdrname);
       strcat(gzname,extzip);
       if (nifti_fileexists(gzname)) {
          fprintf(stderr,"Image Exception : Multiple possible filenames detected for basename (*.nii, *.nii.gz): %s\n", basename);
          free(gzname);
-         exit(13);
+         exit(134);
       }
       free(gzname);
       return hdrname; 
@@ -5299,14 +5298,14 @@ nifti_1_header * nifti_read_n1_hdr(const char * hname, int *swapped, int check)
    hfile = nifti_findhdrname(hname);
    if( hfile == NULL ){
       if( g_opts.debug > 0 )
-         LNI_FERR(fname,"failed to find header file for", hname);
+         LNI_FERR(fname,"failed to find N1 header file for", hname);
       return NULL;
    } else if( g_opts.debug > 1 )
       fprintf(stderr,"-d %s: found header filename '%s'\n",fname,hfile);
 
    fp = znzopen( hfile, "rb", nifti_is_gzfile(hfile) );
    if( znz_isnull(fp) ){
-      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open header file",hfile);
+      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open N1 header file",hfile);
       free(hfile);
       return NULL;
    }
@@ -5400,7 +5399,7 @@ nifti_2_header * nifti_read_n2_hdr(const char * hname, int * swapped,
    hfile = nifti_findhdrname(hname);
    if( hfile == NULL ){
       if( g_opts.debug > 0 )
-         LNI_FERR(fname,"failed to find header file for", hname);
+         LNI_FERR(fname,"failed to find N2 header file for", hname);
       return NULL;
    } else if( g_opts.debug > 1 )
       fprintf(stderr,"-d %s: found N2 header filename '%s'\n",fname,hfile);
@@ -5742,7 +5741,7 @@ void * nifti_read_header( const char *hname, int *nver, int check )
    hfile = nifti_findhdrname(hname);
    if( hfile == NULL ){
       if(g_opts.debug > 0)
-         LNI_FERR(fname,"failed to find header file for", hname);
+         LNI_FERR(fname,"failed to find any header file for", hname);
       return NULL;  /* check return */
    } else if( g_opts.debug > 2 )
       fprintf(stderr,"-d %s: found header filename '%s'\n",fname,hfile);
@@ -5753,7 +5752,7 @@ void * nifti_read_header( const char *hname, int *nver, int check )
    /**- open file, separate reading of header, extensions and data */
    fp = znzopen(hfile, "rb", nifti_is_gzfile(hfile));
    if( znz_isnull(fp) ){
-      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open header file",hfile);
+      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open any header file",hfile);
       free(hfile);
       return NULL;
    }
@@ -5896,7 +5895,7 @@ nifti_image *nifti_image_read( const char *hname , int read_data )
    /**- open file, separate reading of header, extensions and data */
    fp = znzopen(hfile, "rb", nifti_is_gzfile(hfile));
    if( znz_isnull(fp) ){
-      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open header file",hfile);
+      if( g_opts.debug > 0 ) LNI_FERR(fname,"failed to open a header file",hfile);
       free(hfile);
       return NULL;
    }


### PR DESCRIPTION
This is a very simple patch that allows developers to modify the behavior of this library. All are disabled by default, so no change for tools unless they invoke these features.

This provides three compile time options to influence how file handling behavior

1. Related to [issue 129](https://github.com/NIFTI-Imaging/nifti_clib/issues/129). Emulate FSL file handing behavior. Refuse to open `T1.nii` if file `T1.nii.gz` exists. Likewise, refuse to open `T1.nii.gz` if file `T1.nii` exists. This feature  enabled with the directive:
```
#define FSLSTYLE 
```
A conflict generates an error:
```
Multiple possible filenames detected for basename (*.nii, *.nii.gz): T1.nii.gz
```
2. Use pigz parallel compression when writing .nii.gz files if the environment includes the variable `AFNI_COMPRESSOR=PIGZ` and the pigz executable is found. This behavior is enabled by the compiler directive:

```
#define PIGZ
```

3. Refuse to open files of complex datatype. Many tools are not designed for handling complex data. This option is enabled by the compiler directive:

```
#define REJECT_COMPLEX
```
