### PR TITLE
Change include directive of `znzlib.h`

### DIFF
--- a/fsliolib/fslio.h
+++ b/fsliolib/fslio.h
@@ -25,8 +25,8 @@
 #define __FSLIO_H
 
 #include <stdio.h>
-#include <nifti1_io.h>
-#include <znzlib.h>
+#include "nifti1_io.h"
+#include "znzlib.h"
 #include "dbh.h"
 
 #ifdef __cplusplus

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -20,7 +20,7 @@
 #include "nifti1.h"                  /*** NIFTI-1 header specification ***/
 #include "nifti2.h"                  /*** NIFTI-2 header specification ***/
 
-#include <znzlib.h>
+#include "znzlib.h"
 
 /*=================*/
 #ifdef  __cplusplus

--- a/niftilib/nifti1_io.h
+++ b/niftilib/nifti1_io.h
@@ -17,7 +17,7 @@
 #endif
 #include "nifti1.h"                  /*** NIFTI-1 header specification ***/
 
-#include <znzlib.h>
+#include "znzlib.h"
 
 /*=================*/
 #ifdef  __cplusplus


### PR DESCRIPTION
This allows users to avoid adding `-I<PREFIX>/include/nifti` to their include directories and allows them to include `nifti1_io.h` using:
`test.c`:
```c
#include <nifti/nifti1_io.h>

int main() {
   nifti_disp_lib_version();
   return 0;
}
```

This would previously fail with:
```
In file included from test.c:1:
/usr/include/nifti/nifti1_io.h:20:10: fatal error: znzlib.h: No such file or directory
   20 | #include <znzlib.h>
      |          ^~~~~~~~~~
compilation terminated.
```

Test case:
```bash
$ mkdir build && cd build
$ cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr -DNIFTI_INSTALL_LIBRARY_DIR=lib64 ..
$ cmake --build . -- -j$(nproc)
$ sudo cmake --install .
$ gcc test.c -lniftiio -lznz
$ ./a.out
NIFTI1_IO version 2.1.0 (16 Jun, 2022), compiled Jun 24 2022
```
