### PR TITLE
BUG: Fix install of libraries specifying component

### DIFF
--- a/cmake/nifti_macros.cmake
+++ b/cmake/nifti_macros.cmake
@@ -130,10 +130,12 @@ function(install_nifti_target target_name)
           LIBRARY
             DESTINATION ${NIFTI_INSTALL_LIBRARY_DIR}
             COMPONENT RuntimeLibraries
-          COMPONENT Development
-            PUBLIC_HEADER DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
-          COMPONENT Development
-            INCLUDES DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
+          PUBLIC_HEADER
+            DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
+            COMPONENT Development
+          INCLUDES
+            DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
+            COMPONENT Development
           )
 endfunction()
 


### PR DESCRIPTION
This PR's set of changes were originally identified as a fix for 3D Slicer by @jcfr in https://github.com/Slicer/ITK/commit/027fd5ce0c7044c33eb56bf7530466488109390b.

----------------------------------------------

This commit reverts part of https://github.com/NIFTI-Imaging/nifti_clib/commit/3bd6afc7f.

This fixes https://github.com/Slicer/Slicer/issues/6202 ensuring the libraries are not
systematically associated with the Development component.