### PR TITLE
ENH: Hide advanced cmake settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ elseif(NOT WIN32)
 else()
     set(NIFTI_SYSTEM_MATH_LIB "")
 endif()
+mark_as_advanced(NIFTI_SYSTEM_MATH_LIB)
 #######################################################################
 add_subdirectory(znzlib)
 add_subdirectory(niftilib)


### PR DESCRIPTION
The NIFTI_SYSTEM_MATH_LIB variable does not normally need
to be presented to the user as a standard configuration
option.