### PR TITLE
BUG: COMPONENT not valid INCLUDES install option

### DIFF
--- a/cmake/nifti_macros.cmake
+++ b/cmake/nifti_macros.cmake
@@ -135,7 +135,6 @@ function(install_nifti_target target_name)
             COMPONENT Development
           INCLUDES
             DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
-            COMPONENT Development
           )
 endfunction()
 


### PR DESCRIPTION
The INCLUDES element of the install() cmake command only supports
a list of DESTINATION parameters.

[INCLUDES DESTINATION [<dir> ...]]

Introduced in 3aa225403b0acc93f4b86f5eba2f7d2eed042267

The INCLUDES
      DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR} COMPONENT Development

Which creates import items in ${PROJECT}Targets.cmake file
  
```
INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/ITK-5.3:${_IMPORT_PREFIX}/COMPONENT:${_IMPORT_PREFIX}/Development"
```
and subsequently causes errors for 3rd party software includes because
the directories do not exist:

```
${_IMPORT_PREFIX}/COMPONENT and ${_IMPORT_PREFIX}/Development
```