### PR TITLE
64 to 32 truncation warnings

### DIFF
--- a/nifti2/clib_02_nifti2.c
+++ b/nifti2/clib_02_nifti2.c
@@ -117,7 +117,7 @@ int disp_float(nifti_image * nim, int vol, int slice, int line, int offset)
 {
    float     * dp, * d2;
    long long   lloff;
-   int         nx, nxy, nxyz;
+   int64_t     nx, nxy, nxyz;
 
    if( ! nim ) return 1;
 

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -496,12 +496,12 @@ static int  nifti_NBL_matches_nim(const nifti_image *nim,
                                   const nifti_brick_list *NBL);
 
 /* for nifti_read_collapsed_image: */
-static int  rci_read_data(nifti_image *nim, int *pivots, int64_t *prods,
+static int  rci_read_data(nifti_image *nim, int64_t *pivots, int64_t *prods,
                           int nprods, const int64_t dims[], char *data,
                           znzFile fp, int64_t base_offset);
 static int rci_alloc_mem(void **data, const int64_t prods[8], int nprods, int nbyper);
 static int  make_pivot_list(nifti_image * nim, const int64_t dims[],
-                            int pivots[], int64_t prods[], int * nprods );
+                            int64_t pivots[], int64_t prods[], int * nprods );
 
 /* misc */
 static int   compare_strlist   (const char * str, char ** strlist, int len);
@@ -3581,8 +3581,7 @@ int nifti_is_gzfile(const char* fname)
   if (fname == NULL) { return 0; }
 #ifdef HAVE_ZLIB
   { /* just so len doesn't generate compile warning */
-     int len;
-     len = (int)strlen(fname);
+     size_t len = strlen(fname);
      if (len < 3) return 0;  /* so we don't search before the name */
      if (fileext_compare(fname + strlen(fname) - 3,".gz")==0) { return 1; }
   }
@@ -4959,7 +4958,8 @@ nifti_image* nifti_convert_n1hdr2nim(nifti_1_header nhdr, const char * fname)
 *//*--------------------------------------------------------------------*/
 nifti_image* nifti_convert_n2hdr2nim(nifti_2_header nhdr, const char * fname)
 {
-   int          ii, doswap, ni_ver, is_onefile;
+   int64_t      ii;
+   int          doswap, ni_ver, is_onefile;
    nifti_image *nim;
 
    nim = (nifti_image *)calloc( 1 , sizeof(nifti_image) ) ;
@@ -5021,9 +5021,9 @@ nifti_image* nifti_convert_n2hdr2nim(nifti_2_header nhdr, const char * fname)
 
    nim->nifti_type = (is_onefile) ? NIFTI_FTYPE_NIFTI2_1 : NIFTI_FTYPE_NIFTI2_2;
 
-   ii = nifti_short_order() ;
-   if( doswap )   nim->byteorder = REVERSE_ORDER(ii) ;
-   else           nim->byteorder = ii ;
+   int byteOrder = nifti_short_order() ;
+   if( doswap )   nim->byteorder = REVERSE_ORDER(byteOrder) ;
+   else           nim->byteorder = byteOrder ;
 
 
   /**- set dimensions of data array */
@@ -6084,7 +6084,7 @@ nifti_image * nifti_read_ascii_image(znzFile fp, const char *fname, int flen,
                                      int read_data)
 {
    nifti_image * nim;
-   int           slen, txt_size, remain, rv = 0;
+   int           txt_size, remain, rv = 0;
    char        * sbuf, lfunc[25] = { "nifti_read_ascii_image" };
 
    if( nifti_is_gzfile(fname) ){
@@ -6092,11 +6092,11 @@ nifti_image * nifti_read_ascii_image(znzFile fp, const char *fname, int flen,
               fname);
      return NULL;
    }
-   slen = flen;  /* slen will be our buffer length */
+   int64_t slen = flen;  /* slen will be our buffer length */
    if( slen <= 0 ) slen = nifti_get_filesize(fname);
 
    if( g_opts.debug > 1 )
-      fprintf(stderr,"-d %s: have ASCII NIFTI file of size %d\n",fname,slen);
+      fprintf(stderr,"-d %s: have ASCII NIFTI file of size %lld\n",fname,slen);
 
    if( slen > 65530 ) slen = 65530 ;
    sbuf = (char *)calloc(sizeof(char),slen+1) ;
@@ -8987,7 +8987,8 @@ int64_t nifti_read_collapsed_image( nifti_image * nim, const int64_t dims [8],
 {
    znzFile fp;
    int64_t prods[8];          /* sizes are bounded by dims[], so 8 */
-   int     pivots[8], nprods; /* sizes are bounded by dims[], so 8 */
+   int64_t pivots[8];         /* sizes are bounded by dims[], so 8 */
+   int     nprods;
    int64_t c, bytes;
 
    /** - check pointers for sanity */
@@ -9231,7 +9232,7 @@ int64_t nifti_read_subregion_image( nifti_image * nim,
 
    return 0 on success, < 0 on failure
 */
-static int rci_read_data(nifti_image * nim, int * pivots, int64_t * prods,
+static int rci_read_data(nifti_image * nim, int64_t * pivots, int64_t * prods,
                          int nprods, const int64_t dims[], char * data,
                          znzFile fp, int64_t base_offset)
 {
@@ -9250,7 +9251,7 @@ static int rci_read_data(nifti_image * nim, int * pivots, int64_t * prods,
 
       /* make sure things look good here */
       if( *pivots != 0 ){
-         fprintf(stderr,"** NIFTI rciRD: final pivot == %d!\n", *pivots);
+         fprintf(stderr,"** NIFTI rciRD: final pivot == %lld!\n", *pivots);
          return -1;
       }
 
@@ -9353,13 +9354,11 @@ static int rci_alloc_mem(void **data, const int64_t prods[8], int nprods, int nb
    wants to collapse a dimension.  The last pivot should always be zero
    (note that we have space for that in the lists).
 */
-static int make_pivot_list(nifti_image *nim, const int64_t dims[], int pivots[],
+static int make_pivot_list(nifti_image *nim, const int64_t dims[], int64_t pivots[],
                                              int64_t prods[], int * nprods )
 {
-   int len, dind;
-
-   len = 0;
-   dind = nim->dim[0];
+   int len = 0;
+   int64_t dind = nim->dim[0];
    while( dind > 0 ){
       prods[len] = 1;
       while( dind > 0 && (nim->dim[dind] == 1 || dims[dind] == -1) ){
@@ -9383,7 +9382,7 @@ static int make_pivot_list(nifti_image *nim, const int64_t dims[], int pivots[],
    if( g_opts.debug > 2 ){
       fprintf(stderr,"+d pivot list created, pivots :");
       for(dind = 0; dind < len; dind++)
-         fprintf(stderr," %d", pivots[dind]);
+         fprintf(stderr," %lld", pivots[dind]);
       fprintf(stderr,", prods :");
       for(dind = 0; dind < len; dind++)
          fprintf(stderr," %" PRId64 "", prods[dind]);

--- a/nifticdf/nifticdf.c
+++ b/nifticdf/nifticdf.c
@@ -161,7 +161,7 @@ static int K1 = 9;
 static int K3 = 4;
 static int K5 = 5;
 static double alngam,offset,prod,xx;
-static int i,n;
+static long i,n;
 static double T2,T4,T6;
 /*
      ..
@@ -5024,7 +5024,8 @@ static double eps = 1.0e-5;
 static int ntired = 1000;
 static double adj,centaj,centwt,chid2,dfd2,lcntaj,lcntwt,lfact,pcent,pterm,sum,
     sumadj,term,wt,xnonc;
-static int i,icent,iterb,iterf;
+static int iterb,iterf;
+static long i,icent;
 static double T1,T2,T3;
 /*
      ..
@@ -8141,7 +8142,8 @@ static double q[7] = {
 static int K2 = 3;
 static int K3 = 0;
 static double Xgamm,bot,g,lnx,s,t,top,w,x,z;
-static int i,j,m,n,T1;
+static int i;
+static long j,n,m,T1;
 /*
      ..
      .. Executable Statements ..
@@ -8454,7 +8456,8 @@ static int K1 = 1;
 static int K2 = 0;
 static double a2n,a2nm1,acc,am0,amn,an,an0,apn,b2n,b2nm1,c,c0,c1,c2,c3,c4,c5,c6,
     cma,e,e0,g,h,j,l,r,rta,rtx,s,sum,t,t1,tol,twoa,u,w,x0,y,z;
-static int i,iop,m,max,n;
+static int iop;
+static long i,m,max,n;
 static double wk[20],T3;
 static int T4,T5;
 static double T6,T7;
@@ -8852,7 +8855,8 @@ static double q2[4] = {
 static int K1 = 3;
 static int K2 = 1;
 static double psi,aug,den,sgn,upper,w,x,xmax1,xmx0,xsmall,z;
-static int i,m,n,nq;
+static int i;
+static long m,n,nq;
 /*
      ..
      .. Executable Statements ..

--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -4,6 +4,9 @@
 #include "nifti1_io.h"   /* typedefs, prototypes, macros, etc. */
 #include "nifti1_io_version.h"
 
+#include <errno.h>
+#include <limits.h>
+
 /*****===================================================================*****/
 /*****     Sample functions to deal with NIFTI-1 and ANALYZE files       *****/
 /*****...................................................................*****/
@@ -2661,8 +2664,7 @@ int nifti_is_gzfile(const char* fname)
   if (fname == NULL) { return 0; }
 #ifdef HAVE_ZLIB
   { /* just so len doesn't generate compile warning */
-     int len;
-     len = (int)strlen(fname);
+     size_t len = strlen(fname);
      if (len < 3) return 0;  /* so we don't search before the name */
      if (fileext_compare(fname + strlen(fname) - 3,".gz")==0) { return 1; }
   }
@@ -4394,7 +4396,7 @@ static int nifti_read_extensions( nifti_image *nim, znzFile fp, int remain )
    nifti1_extender    extdr;      /* defines extension existence  */
    nifti1_extension   extn;       /* single extension to process  */
    nifti1_extension * Elist;      /* list of processed extensions */
-   int                posn, count;
+   int                count;
 
    if( !nim || znz_isnull(fp) ) {
       if( g_opts.debug > 0 )
@@ -4403,15 +4405,15 @@ static int nifti_read_extensions( nifti_image *nim, znzFile fp, int remain )
       return -1;
    }
 
-   posn = znztell(fp);
+   znz_off_t posn = znztell(fp);
 
    if( (posn != sizeof(nifti_1_header)) &&
        (nim->nifti_type != NIFTI_FTYPE_ASCII) )
-      fprintf(stderr,"** WARNING: posn not header size (%d, %d)\n",
-              posn, (int)sizeof(nifti_1_header));
+      fprintf(stderr,"** WARNING: posn not header size (%lld, %lu)\n",
+              posn, sizeof(nifti_1_header));
 
    if( g_opts.debug > 2 )
-      fprintf(stderr,"-d nre: posn = %d, offset = %d, type = %d, remain = %d\n",
+       fprintf(stderr,"-d nre: posn = %lld, offset = %d, type = %d, remain = %d\n",
               posn, nim->iname_offset, nim->nifti_type, remain);
 
    if( remain < 16 ){
@@ -7334,7 +7336,7 @@ int * nifti_get_intlist( int nvals , const char * str )
    int *subv = NULL ;
    int *subv_realloc = NULL;
    int ii , ipos , nout , slen ;
-   int ibot,itop,istep , nused ;
+   int ibot,itop,istep ;
    char *cpt ;
 
    /* Meaningless input? */
@@ -7370,18 +7372,24 @@ int * nifti_get_intlist( int nvals , const char * str )
       if( str[ipos] == '$' ){  /* special case */
          ibot = nvals-1 ; ipos++ ;
       } else {                 /* decode an integer */
-         ibot = strtol( str+ipos , &cpt , 10 ) ;
+         errno = 0;
+         long temp = strtol( str+ipos , &cpt , 10 ) ;
+         if( (temp == 0 && errno != 0) || temp <= INT_MIN || temp >= INT_MAX){
+            fprintf(stderr,"** ERROR: list index does not fit in int\n") ;
+            free(subv) ; return NULL ;
+         }
+         ibot = (int)temp;
          if( ibot < 0 ){
-           fprintf(stderr,"** ERROR: list index %d is out of range 0..%d\n",
+            fprintf(stderr,"** ERROR: list index %d is out of range 0..%d\n",
                    ibot,nvals-1) ;
            free(subv) ; return NULL ;
          }
          if( ibot >= nvals ){
-           fprintf(stderr,"** ERROR: list index %d is out of range 0..%d\n",
+            fprintf(stderr,"** ERROR: list index %d is out of range 0..%d\n",
                    ibot,nvals-1) ;
            free(subv) ; return NULL ;
          }
-         nused = (cpt-(str+ipos)) ;
+         long nused = (cpt-(str+ipos)) ;
          if( ibot == 0 && nused == 0 ){
            fprintf(stderr,"** ERROR: list syntax error '%s'\n",str+ipos) ;
            free(subv) ; return NULL ;
@@ -7427,7 +7435,13 @@ int * nifti_get_intlist( int nvals , const char * str )
       if( str[ipos] == '$' ){  /* special case */
          itop = nvals-1 ; ipos++ ;
       } else {                 /* decode an integer */
-         itop = strtol( str+ipos , &cpt , 10 ) ;
+         errno = 0;
+         long temp = strtol( str+ipos , &cpt , 10 ) ;
+         if( (temp == 0 && errno != 0) || temp <= INT_MIN || temp >= INT_MAX){
+            fprintf(stderr,"** ERROR: list index does not fit in int\n") ;
+            free(subv) ; return NULL ;
+         }
+         itop = (int)temp;
          if( itop < 0 ){
            fprintf(stderr,"** ERROR: index %d is out of range 0..%d\n",
                    itop,nvals-1) ;
@@ -7438,7 +7452,7 @@ int * nifti_get_intlist( int nvals , const char * str )
                    itop,nvals-1) ;
            free(subv) ; return NULL ;
          }
-         nused = (cpt-(str+ipos)) ;
+         long nused = (cpt-(str+ipos)) ;
          if( itop == 0 && nused == 0 ){
            fprintf(stderr,"** ERROR: index list syntax error '%s'\n",str+ipos) ;
            free(subv) ; return NULL ;
@@ -7456,12 +7470,18 @@ int * nifti_get_intlist( int nvals , const char * str )
 
       if( str[ipos] == '(' ){  /* decode an integer */
          ipos++ ;
-         istep = strtol( str+ipos , &cpt , 10 ) ;
+         errno = 0;
+         long temp = strtol( str+ipos , &cpt , 10 ) ;
+         if( (temp == 0 && errno != 0) || temp <= INT_MIN || temp >= INT_MAX){
+            fprintf(stderr,"** ERROR: list index does not fit in int\n") ;
+            free(subv) ; return NULL ;
+         }
+         istep = (int)temp;
          if( istep == 0 ){
            fprintf(stderr,"** ERROR: index loop step is 0!\n") ;
            free(subv) ; return NULL ;
          }
-         nused = (cpt-(str+ipos)) ;
+         long nused = (cpt-(str+ipos)) ;
          ipos += nused ;
          if( str[ipos] == ')' ) ipos++ ;
          if( (ibot-itop)*istep > 0 ){

--- a/niftilib/nifti1_test.c
+++ b/niftilib/nifti1_test.c
@@ -17,7 +17,7 @@ static int local_fileexists(const char* fname)
 int main( int argc , char *argv[] )
 {
    nifti_image *nim ;
-   int iarg=1 , outmode=1 , ll , argn=1, usegzip=0;
+   int iarg=1 , outmode=1 , argn=1, usegzip=0;
    char *tmpstr;
 
    if( argc < 2 || strcmp(argv[1],"-help") == 0 ){
@@ -78,7 +78,7 @@ int main( int argc , char *argv[] )
    if( nim->fname != NULL ) free(nim->fname) ;
    if( nim->iname != NULL ) free(nim->iname) ;
 
-   ll = strlen(argv[iarg]) ;
+   size_t ll = strlen(argv[iarg]) ;
    tmpstr = nifti_makebasename(argv[iarg]);
    nim->fname = (char *)calloc(1,ll+8) ; strcpy(nim->fname,tmpstr) ;
    nim->iname = (char *)calloc(1,ll+8) ; strcpy(nim->iname,tmpstr) ;

--- a/niftilib/nifti1_tool.c
+++ b/niftilib/nifti1_tool.c
@@ -162,6 +162,7 @@ static const char * g_history[] =
 static char g_version[] = "version 1.24 (September 26, 2012)";
 static int  g_debug = 1;
 
+#include <limits.h>
 #include <string.h>
 #include <stdint.h>
 
@@ -171,7 +172,7 @@ static int  g_debug = 1;
 /* local prototypes */
 static int free_opts_mem(nt_opts * nopt);
 static int num_volumes(nifti_image * nim);
-static char * read_file_text(const char * filename, int * length);
+static char * read_file_text(const char * filename, int64_t * length);
 
 #define NTL_FERR(func,msg,file)                                      \
             fprintf(stderr,"** ERROR (%s): %s '%s'\n",func,msg,file)
@@ -688,13 +689,13 @@ int verify_opts( nt_opts * opts, char * prog )
 int fill_cmd_string( nt_opts * opts, int argc, char * argv[])
 {
    char * cp;
-   int    len, remain = sizeof(opts->command);  /* max command len */
+   size_t remain = sizeof(opts->command);  /* max command len */
    int    c, ac;
    int    has_space;  /* arguments containing space must be quoted */
    int    skip = 0;   /* counter to skip some of the arguments     */
 
    /* get the first argument separately */
-   len = snprintf( opts->command, sizeof(opts->command), "\n  command: %s", argv[0] );
+   int len = snprintf( opts->command, sizeof(opts->command), "\n  command: %s", argv[0] );
    if( len < 0 || len >= (int)sizeof(opts->command) ) {
       fprintf(stderr,"FCS: no space remaining for command, continuing...\n");
       return 1;
@@ -707,7 +708,7 @@ int fill_cmd_string( nt_opts * opts, int argc, char * argv[])
    {
       if( skip ){ skip--;  continue; }  /* then skip these arguments */
 
-      len = strlen(argv[ac]);
+      size_t len = strlen(argv[ac]);
       if( len + 3 >= remain ) {  /* extra 3 for space and possible '' */
          fprintf(stderr,"FCS: no space remaining for command, continuing...\n");
          return 1;
@@ -1823,7 +1824,8 @@ int act_add_exts( nt_opts * opts )
    nifti_image      * nim;
    const char       * ext;
    char             * edata = NULL;
-   int                fc, ec, elen;
+   int                fc, ec;
+   int64_t            elen;
 
    if( g_debug > 2 ){
       fprintf(stderr,"+d adding %d extensions to %d files...\n"
@@ -1850,7 +1852,7 @@ int act_add_exts( nt_opts * opts )
          elen = strlen(ext);
          if( !strncmp(ext,"file:",5) ){
             edata = read_file_text(ext+5, &elen);
-            if( !edata || elen <= 0 ) {
+            if( !edata || elen <= 0 || elen > INT_MAX) {
                fprintf(stderr,"** failed to read extension data from '%s'\n",
                        ext+5);
                continue;
@@ -1858,7 +1860,7 @@ int act_add_exts( nt_opts * opts )
             ext = edata;
          }
 
-         if( nifti_add_extension(nim, ext, elen, opts->etypes.list[ec]) ){
+         if( nifti_add_extension(nim, ext, (int)elen, opts->etypes.list[ec]) ){
             nifti_image_free(nim);
             return 1;
          }
@@ -1868,7 +1870,7 @@ int act_add_exts( nt_opts * opts )
       }
 
       if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                             strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                             (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
          fprintf(stderr,"** failed to add command to image as extension\n");
 
       if( opts->prefix &&
@@ -1902,24 +1904,20 @@ int act_add_exts( nt_opts * opts )
 /*----------------------------------------------------------------------
  * Return the allocated file contents.
  *----------------------------------------------------------------------*/
-static char * read_file_text(const char * filename, int * length)
+static char * read_file_text(const char * filename, int64_t * length)
 {
-   FILE * fp;
-   char * text;
-   int    len, bytes;
-
    if( !filename || !length ) {
       fprintf(stderr,"** bad params to read_file_text\n");
       return NULL;
    }
 
-   len = nifti_get_filesize(filename);
+   int64_t len = nifti_get_filesize(filename);
    if( len <= 0 ) {
       fprintf(stderr,"** RFT: file '%s' appears empty\n", filename);
       return NULL;
    }
 
-   fp = fopen(filename, "r");
+   FILE * fp = fopen(filename, "r");
    if( !fp ) {
       fprintf(stderr,"** RFT: failed to open '%s' for reading\n", filename);
       return NULL;
@@ -1927,18 +1925,18 @@ static char * read_file_text(const char * filename, int * length)
 
    /* allocate the bytes, and fill them with the file contents */
 
-   text = (char *)malloc(len * sizeof(char));
+   char * text = (char *)malloc(len * sizeof(char));
    if( !text ) {
-      fprintf(stderr,"** RFT: failed to allocate %d bytes\n", len);
+      fprintf(stderr,"** RFT: failed to allocate %lld bytes\n", len);
       fclose(fp);
       return NULL;
    }
 
-   bytes = fread(text, sizeof(char), len, fp);
+   size_t bytes = fread(text, sizeof(char), len, fp);
    fclose(fp); /* in any case */
 
    if( bytes != len ) {
-      fprintf(stderr,"** RFT: read only %d of %d bytes from %s\n",
+      fprintf(stderr,"** RFT: read only %zu of %lld bytes from %s\n",
                      bytes, len, filename);
       free(text);
       return NULL;
@@ -1947,7 +1945,7 @@ static char * read_file_text(const char * filename, int * length)
    /* success */
 
    if( g_debug > 1 ) {
-      fprintf(stderr,"++ found extension of length %d in file %s\n",
+      fprintf(stderr,"++ found extension of length %lld in file %s\n",
               len, filename);
       if( g_debug > 2 )
          fprintf(stderr,"++ text is:\n%s\n", text);
@@ -2066,7 +2064,7 @@ int act_rm_ext( nt_opts * opts )
          return 1;
 
       if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                             strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                             (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
          fprintf(stderr,"** failed to add command to image as extension\n");
 
       if( opts->prefix &&
@@ -2601,7 +2599,7 @@ int act_mod_hdrs( nt_opts * opts )
             return 1;
          }
          if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                                strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                                (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
                fprintf(stderr,"** failed to add command to image as extension\n");
          if( nifti_set_filenames(nim, opts->prefix, 1, 1) )
          {
@@ -2722,7 +2720,7 @@ int act_swap_hdrs( nt_opts * opts )
             return 1;
          }
          if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                                strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                                (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
                fprintf(stderr,"** failed to add command to image as extension\n");
          if( nifti_set_filenames(nim, opts->prefix, 1, 1) )
          {
@@ -2787,7 +2785,7 @@ int act_mod_nims( nt_opts * opts )
 
       /* add command as COMMENT extension */
       if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                             strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                             (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
          fprintf(stderr,"** failed to add command to image as extension\n");
 
       /* possibly duplicate the current dataset before writing new header */
@@ -2897,7 +2895,8 @@ int modify_field(void * basep, field_s * field, const char * data)
    if( g_debug > 1 )
       fprintf(stderr,"+d modifying field '%s' with '%s'\n", field->name, data);
 
-   if( !data || strlen(data) == 0 )
+   size_t dataLength = strlen(data);
+   if( !data || dataLength == 0 )
    {
       fprintf(stderr,"** no data for '%s' field modification\n",field->name);
       return 1;
@@ -3012,10 +3011,9 @@ int modify_field(void * basep, field_s * field, const char * data)
          case NT_DT_STRING:
          {
             char * dest = (char *)basep + field->offset;
-            nchars = strlen(data);
             strncpy(dest, data, field->len);
-            if( nchars < field->len )  /* clear the rest */
-               memset(dest+nchars, '\0', field->len-nchars);
+            if( dataLength < field->len )  /* clear the rest */
+               memset(dest+dataLength, '\0', field->len - dataLength);
          }
          break;
    }
@@ -3917,11 +3915,10 @@ int disp_raw_data( void * data, int type, int nvals, char space, int newline )
 int clear_float_zeros( char * str )
 {
    char * dp  = strchr(str, '.'), * valp;
-   int    len;
 
    if( !dp ) return 0;      /* nothing to clear */
 
-   len = strlen(dp);
+   size_t len = strlen(dp);
 
    /* never clear what is just to the right of '.' */
    for( valp = dp+len-1; (valp > dp+1) && (*valp==' ' || *valp=='0'); valp-- )
@@ -4004,7 +4001,7 @@ int act_cbl( nt_opts * opts )
 
    /* add command as COMMENT extension */
    if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                          strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                          (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
       fprintf(stderr,"** failed to add command to image as extension\n");
 
    /* replace filenames using prefix */
@@ -4062,7 +4059,7 @@ int act_cci( nt_opts * opts )
 
    /* add command as COMMENT extension */
    if( opts->keep_hist && nifti_add_extension(nim, opts->command,
-                          strlen(opts->command), NIFTI_ECODE_COMMENT) )
+                          (int)strlen(opts->command), NIFTI_ECODE_COMMENT) )
       fprintf(stderr,"** failed to add command to image as extension\n");
 
    /* replace filenames using prefix */

--- a/znzlib/znzlib.c
+++ b/znzlib/znzlib.c
@@ -143,7 +143,7 @@ size_t znzread(void* buf, size_t size, size_t nmemb, znzFile file)
     /* gzread/write take unsigned int length, so maybe read in int pieces
        (noted by M Hanke, example given by M Adler)   6 July 2010 [rickr] */
     while( remain > 0 ) {
-       n2read = (remain < ZNZ_MAX_BLOCK_SIZE) ? remain : ZNZ_MAX_BLOCK_SIZE;
+       n2read = (remain < ZNZ_MAX_BLOCK_SIZE) ? (unsigned)remain : ZNZ_MAX_BLOCK_SIZE;
        nread = gzread(file->zfptr, (void *)cbuf, n2read);
        if( nread < 0 ) return nread; /* returns -1 on error */
 
@@ -175,7 +175,7 @@ size_t znzwrite(const void* buf, size_t size, size_t nmemb, znzFile file)
 #ifdef HAVE_ZLIB
   if (file->zfptr!=NULL) {
     while( remain > 0 ) {
-       n2write = (remain < ZNZ_MAX_BLOCK_SIZE) ? remain : ZNZ_MAX_BLOCK_SIZE;
+       n2write = (remain < ZNZ_MAX_BLOCK_SIZE) ? (unsigned)remain : ZNZ_MAX_BLOCK_SIZE;
        nwritten = gzwrite(file->zfptr, (const void *)cbuf, n2write);
 
        /* gzread returns 0 on error, but in case that ever changes... */


### PR DESCRIPTION
@afni-rickr @mrneont @hjmjohnson This PR fixes all -Wshorten-64-to-32 warnings, which is when a 64 bit integer is implicitly stored into a 32 bit integer.  Obviously this can be lossy.  I divided it into two commits, one that doesn't change any public API, and one that does.  (By public API I mean things declared in header files.)

I imagine you won't be too keen on changing the public API :), but hopefully you'll agree with the first commit at least.
