### PR TITLE
Fix reading subregions of large files

### DIFF
--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -6969,7 +6969,7 @@ int nifti_read_subregion_image( nifti_image * nim,
   znzFile fp;                   /* file to read */
   int i,j,k,l,m,n;              /* indices for dims */
   long int bytes = 0;           /* total # bytes read */
-  int total_alloc_size;         /* size of buffer allocation */
+  size_t total_alloc_size;      /* size of buffer allocation */
   char *readptr;                /* where in *data to read next */
   int strides[7];               /* strides between dimensions */
   int collapsed_dims[8];        /* for read_collapsed_image */
@@ -7065,8 +7065,8 @@ int nifti_read_subregion_image( nifti_image * nim,
     if(g_opts.debug > 1)
       {
       fprintf(stderr,"allocation of %d bytes failed\n",total_alloc_size);
-      return -1;
       }
+    return -1;
     }
 
   /* point to start of data buffer as char * */


### PR DESCRIPTION
The type (int) of `total_alloc_size` limits the memory allocation to 2 GiB.

Fixes #158

---
~~Open problems/questions:~~
- ~~the return value is still a `int` and returns a negative value for buffers bigger than 2 GiB.
  This requires a change in signature:
  (Would break 32bit builds)~~
  1. ~~change `bytes` and return type to `long long int`~~
  2. ~~change `bytes` and return type to `int64_t`~~
 - ~~maybe also adapt `initial_offset` and `offset`?~~