### PR TITLE
Fixed some cppcheck warnings that were real bugs

### DIFF
--- a/nifti2/nifti_tool.c
+++ b/nifti2/nifti_tool.c
@@ -7482,6 +7482,7 @@ void * nt_read_header(const char * fname, int * nver, int * swapped, int check,
 
            nim = nifti_convert_n1hdr2nim(*(nifti_1_header*)nptr, NULL);
            if( !nim ) {
+              free(hdr);
               fprintf(stderr,"** %s: failed n1hdr2nim on %s\n", func, fname);
               return NULL;
            }

--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -3227,12 +3227,17 @@ static int fileext_compare(const char * test_ext, const char * known_ext)
 {
    char caps[8] = "";
    size_t c,len;
+
+   /* Pointer-equal is equal, including both NULL. */
+   if( test_ext == known_ext ) return 0;
+
+   /* If one is NULL consider it as less than the other. */
+   if( !test_ext ) return -1;
+   if( !known_ext ) return 1;
+
    /* if equal, don't need to check case (store to avoid multiple calls) */
    const int cmp = strcmp(test_ext, known_ext);
    if( cmp == 0 ) return cmp;
-
-   /* if anything odd, use default */
-   if( !test_ext || !known_ext ) return cmp;
 
    len = strlen(known_ext);
    if( len > 7 ) return cmp;
@@ -3252,12 +3257,17 @@ static int fileext_n_compare(const char * test_ext,
 {
    char caps[8] = "";
    size_t c,len;
+
+   /* Pointer-equal is equal, including both NULL. */
+   if( test_ext == known_ext ) return 0;
+
+   /* If one is NULL consider it as less than the other. */
+   if( !test_ext ) return -1;
+   if( !known_ext ) return 1;
+
    /* if equal, don't need to check case (store to avoid multiple calls) */
    const int  cmp = strncmp(test_ext, known_ext, maxlen);
    if( cmp == 0 ) return cmp;
-
-   /* if anything odd, use default */
-   if( !test_ext || !known_ext ) return cmp;
 
    len = strlen(known_ext);
    if( len > maxlen ) len = maxlen;     /* ignore anything past maxlen */
@@ -4536,8 +4546,8 @@ static int nifti_add_exten_to_list( nifti1_extension *  new_ext,
 
    /* check for failure first */
    if( ! *list ){
-      fprintf(stderr,"** failed to alloc %d extension structs (%d bytes)\n",
-              new_length, new_length*(int)sizeof(nifti1_extension));
+      fprintf(stderr,"** failed to alloc %d extension structs (%zu bytes)\n",
+              new_length, new_length*sizeof(nifti1_extension));
       if( !tmplist ) return -1;  /* no old list to lose */
 
       *list = tmplist;  /* reset list to old one */
@@ -6193,7 +6203,7 @@ static char *escapize_string( const char * str )
 *//*-------------------------------------------------------------------------*/
 char *nifti_image_to_ascii( const nifti_image *nim )
 {
-   char *buf , *ebuf ; int nbuf ;
+   char *buf , *ebuf , *newbuf; int nbuf ;
 
    if( nim == NULL ) return NULL ;   /* stupid caller */
 
@@ -6430,9 +6440,12 @@ char *nifti_image_to_ascii( const nifti_image *nim )
    snprintf( buf+strlen(buf) , bufLen-strlen(buf) , "/>\n" ) ;   /* XML-ish closer */
 
    nbuf = (int)strlen(buf) ;
-   buf  = (char *)realloc((void *)buf, nbuf+1); /* cut back to proper length */
-   if( !buf ) fprintf(stderr,"** NITA: failed to realloc %d bytes\n",nbuf+1);
-   return buf ;
+   newbuf = (char *)realloc((void *)buf, nbuf+1); /* cut back to proper length */
+   if( !newbuf ){
+      free(buf);
+      fprintf(stderr,"** NITA: failed to realloc %d bytes\n",nbuf+1);
+   }
+   return newbuf ;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fixes:

```
nifti2/nifti2_io.c:4183:27: warning: Either the condition '!test_ext' is redundant or there is possible null pointer dereference: test_ext. [nullPointerRedundantCheck]
nifti2/nifti2_io.c:4183:37: warning: Either the condition '!known_ext' is redundant or there is possible null pointer dereference: known_ext. [nullPointerRedundantCheck]
nifti2/nifti2_io.c:4187:8: note: Assuming that condition '!test_ext' is not redundant
nifti2/nifti2_io.c:4208:29: warning: Either the condition '!test_ext' is redundant or there is possible null pointer dereference: test_ext. [nullPointerRedundantCheck]
nifti2/nifti2_io.c:4208:39: warning: Either the condition '!known_ext' is redundant or there is possible null pointer dereference: known_ext. [nullPointerRedundantCheck]
nifti2/nifti2_io.c:6296:7: warning: %d in format string (no. 2) requires 'int' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_sint]
nifti2/nifti_tool.c:7478:15: warning: Memory leak: hdr [memleak]
nifti2/nifti_tool.c:7491:15: warning: Memory leak: hdr [memleak]
niftilib/nifti1_io.c:3225:27: warning: Either the condition '!test_ext' is redundant or there is possible null pointer dereference: test_ext. [nullPointerRedundantCheck]
niftilib/nifti1_io.c:3225:37: warning: Either the condition '!known_ext' is redundant or there is possible null pointer dereference: known_ext. [nullPointerRedundantCheck]
niftilib/nifti1_io.c:3250:29: warning: Either the condition '!test_ext' is redundant or there is possible null pointer dereference: test_ext. [nullPointerRedundantCheck]
niftilib/nifti1_io.c:3250:39: warning: Either the condition '!known_ext' is redundant or there is possible null pointer dereference: known_ext. [nullPointerRedundantCheck]
niftilib/nifti1_io.c:4532:7: warning: %d in format string (no. 2) requires 'int' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_sint]
```
