### PR TITLE
Fixed various type punning warnings by using memcpy()

### DIFF
--- a/nifti2/nifti_tool.c
+++ b/nifti2/nifti_tool.c
@@ -3822,7 +3822,6 @@ int modify_all_fields( void * basep, nt_opts * opts, field_s * fields, int flen)
  *----------------------------------------------------------------------*/
 int modify_field(void * basep, field_s * field, const char * data)
 {
-   float   fval;
    const char  * posn = data;
    int     val, max, fc, nchars;
 
@@ -3849,7 +3848,7 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_INT8:
          {
-            max = 127;
+            max = INT8_MAX;
             for( fc = 0; fc < field->len; fc++ )
             {
                if( sscanf(posn, " %d%n", &val, &nchars) != 1 )
@@ -3877,7 +3876,7 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_INT16:
          {
-            max = 32767;
+            max = INT16_MAX;
             for( fc = 0; fc < field->len; fc++ )
             {
                if( sscanf(posn, " %d%n", &val, &nchars) != 1 )
@@ -3894,7 +3893,9 @@ int modify_field(void * basep, field_s * field, const char * data)
                   return 1;
                }
                /* otherwise, we're good */
-               ((short *)((char *)basep + field->offset))[fc] = (short)val;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               int16_t sval = (int16_t)val;
+               memcpy(offsetp, &sval, sizeof(sval));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %d\n",
                           fc, field->name, val);
@@ -3913,7 +3914,9 @@ int modify_field(void * basep, field_s * field, const char * data)
                           fc,field->len);
                   return 1;
                }
-               ((int *)((char *)basep + field->offset))[fc] = val;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               int32_t ival = (int32_t)val;
+               memcpy(offsetp, &ival, sizeof(ival));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %d\n",
                           fc, field->name, val);
@@ -3933,7 +3936,8 @@ int modify_field(void * basep, field_s * field, const char * data)
                           fc,field->len);
                   return 1;
                }
-               ((int64_t *)((char *)basep + field->offset))[fc] = v64;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               memcpy(offsetp, &v64, sizeof(v64));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %" PRId64 "\n",
                           fc, field->name, v64);
@@ -3944,19 +3948,21 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_FLOAT32:
          {
+            float f32;
             for( fc = 0; fc < field->len; fc++ )
             {
-               if( sscanf(posn, " %f%n", &fval, &nchars) != 1 )
+               if( sscanf(posn, " %f%n", &f32, &nchars) != 1 )
                {
                   fprintf(stderr,"** found %d of %d modify values\n",
                           fc,field->len);
                   return 1;
                }
                /* otherwise, we're good */
-               ((float *)((char *)basep + field->offset))[fc] = fval;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               memcpy(offsetp, &f32, sizeof(f32));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %f\n",
-                          fc, field->name, fval);
+                          fc, field->name, f32);
                posn += nchars;
             }
          }
@@ -3974,7 +3980,8 @@ int modify_field(void * basep, field_s * field, const char * data)
                   return 1;
                }
                /* otherwise, we're good */
-               ((double *)((char *)basep + field->offset))[fc] = f64;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               memcpy(offsetp, &f64, sizeof(f64));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %f\n",
                           fc, field->name, f64);

--- a/niftilib/nifti1_tool.c
+++ b/niftilib/nifti1_tool.c
@@ -2888,7 +2888,6 @@ int modify_all_fields( void * basep, nt_opts * opts, field_s * fields, int flen)
  *----------------------------------------------------------------------*/
 int modify_field(void * basep, field_s * field, const char * data)
 {
-   float         fval;
    const char  * posn = data;
    int           val, max, fc, nchars;
 
@@ -2915,7 +2914,7 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_INT8:
          {
-            max = 127;
+            max = INT8_MAX;
             for( fc = 0; fc < field->len; fc++ )
             {
                if( sscanf(posn, " %d%n", &val, &nchars) != 1 )
@@ -2943,7 +2942,7 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_INT16:
          {
-            max = 32767;
+            max = INT16_MAX;
             for( fc = 0; fc < field->len; fc++ )
             {
                if( sscanf(posn, " %d%n", &val, &nchars) != 1 )
@@ -2960,7 +2959,9 @@ int modify_field(void * basep, field_s * field, const char * data)
                   return 1;
                }
                /* otherwise, we're good */
-               ((short *)((char *)basep + field->offset))[fc] = (short)val;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               int16_t sval = (int16_t)val;
+               memcpy(offsetp, &sval, sizeof(sval));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %d\n",
                           fc, field->name, val);
@@ -2979,7 +2980,9 @@ int modify_field(void * basep, field_s * field, const char * data)
                           fc,field->len);
                   return 1;
                }
-               ((int *)((char *)basep + field->offset))[fc] = val;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               int32_t ival = (int32_t)val;
+               memcpy(offsetp, &ival, sizeof(ival));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %d\n",
                           fc, field->name, val);
@@ -2990,19 +2993,21 @@ int modify_field(void * basep, field_s * field, const char * data)
 
          case DT_FLOAT32:
          {
+            float f32;
             for( fc = 0; fc < field->len; fc++ )
             {
-               if( sscanf(posn, " %f%n", &fval, &nchars) != 1 )
+               if( sscanf(posn, " %f%n", &f32, &nchars) != 1 )
                {
                   fprintf(stderr,"** found %d of %d modify values\n",
                           fc,field->len);
                   return 1;
                }
                /* otherwise, we're good */
-               ((float *)((char *)basep + field->offset))[fc] = fval;
+               char * offsetp = &(((char *)basep + field->offset)[fc]);
+               memcpy(offsetp, &f32, sizeof(f32));
                if( g_debug > 1 )
                   fprintf(stderr,"+d setting posn %d of '%s' to %f\n",
-                          fc, field->name, fval);
+                          fc, field->name, f32);
                posn += nchars;
             }
          }


### PR DESCRIPTION
Modern compilers optimize memcpy() very well, this will likely produce the same code.