### PR TITLE
Increased an integer to long to fix signed integer overflow

### DIFF
--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -6928,7 +6928,7 @@ int nifti_read_collapsed_image( nifti_image * nim, const int dims [8],
 ** stride array.
 */
 static void
-compute_strides(int *strides,const int *size,int nbyper)
+compute_strides(int64_t *strides,const int *size,int nbyper)
 {
   int i;
   strides[0] = nbyper;
@@ -6977,7 +6977,7 @@ int nifti_read_subregion_image( nifti_image * nim,
   long int bytes = 0;           /* total # bytes read */
   size_t total_alloc_size;      /* size of buffer allocation */
   char *readptr;                /* where in *data to read next */
-  int strides[7];               /* strides between dimensions */
+  int64_t strides[7];           /* strides between dimensions */
   int collapsed_dims[8];        /* for read_collapsed_image */
   int *image_size;              /* pointer to dimensions in header */
   long int initial_offset;


### PR DESCRIPTION
With the ITK unit test itkNiftiLargeImageRegionReadTest, UBSan correctly reported:

runtime error: signed integer overflow: 1020 * 2138312 cannot be represented in type 'int'

Luckily, the private variable `strides` can just be made long.