### PR TITLE
Removed unnecessary guards against free(NULL)

### DIFF
--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -897,7 +897,7 @@ void nifti_free_NBL( nifti_brick_list * NBL )
 
    if( NBL->bricks ){
       for( c = 0; c < NBL->nbricks; c++ )
-         if( NBL->bricks[c] ) free(NBL->bricks[c]);
+         free(NBL->bricks[c]);
       free(NBL->bricks);
       NBL->bricks = NULL;
    }
@@ -1072,8 +1072,8 @@ static int nifti_copynsort(int64_t nbricks, const int64_t *blist,
    if( !*slist || !*sindex ){
       fprintf(stderr,"** NIFTI NCS: failed to alloc %" PRId64
               " ints for sorting\n", nbricks);
-      if(*slist)  free(*slist);   /* maybe one succeeded */
-      if(*sindex) free(*sindex);
+      free(*slist);   /* maybe one succeeded */
+      free(*sindex);
       return -1;
    }
 
@@ -4039,8 +4039,8 @@ int nifti_set_filenames( nifti_image * nim, const char * prefix, int check,
       fprintf(stderr,"+d modifying output filenames using prefix %s\n", prefix);
 
    /* set and test output filenames */
-   if( nim->fname ) free(nim->fname);
-   if( nim->iname ) free(nim->iname);
+   free(nim->fname);
+   free(nim->iname);
    nim->iname = NULL;
    nim->fname = nifti_makehdrname(prefix, nim->nifti_type, check, comp);
    if( nim->fname )
@@ -6895,9 +6895,9 @@ void nifti_image_unload( nifti_image *nim )
 void nifti_image_free( nifti_image *nim )
 {
    if( nim == NULL ) return ;
-   if( nim->fname != NULL ) free(nim->fname) ;
-   if( nim->iname != NULL ) free(nim->iname) ;
-   if( nim->data  != NULL ) free(nim->data ) ;
+   free(nim->fname) ;
+   free(nim->iname) ;
+   free(nim->data ) ;
    (void)nifti_free_extensions( nim ) ;
    free(nim) ; }
 
@@ -6919,7 +6919,7 @@ int nifti_free_extensions( nifti_image *nim )
    if( nim == NULL ) return -1;
    if( nim->num_ext > 0 && nim->ext_list ){
       for( c = 0; c < nim->num_ext; c++ )
-         if ( nim->ext_list[c].edata ) free(nim->ext_list[c].edata);
+         free(nim->ext_list[c].edata);
       free(nim->ext_list);
    }
    /* or if it is inconsistent, warn the user (if we are not in quiet mode) */
@@ -8960,7 +8960,7 @@ int nifti_nim_has_valid_dims(nifti_image * nim, int complain)
              ret_val = nifti_read_collapsed_image(nim, dims, &data);
              if( ret_val > 0 ){
                 process_time_series(data);
-                if( data != NULL ) free(data);
+                free(data);
              }
            }
 
@@ -8975,7 +8975,7 @@ int nifti_nim_has_valid_dims(nifti_image * nim, int complain)
                 ret_val = nifti_read_collapsed_image(nim, dims, &data);
                 if( ret_val > 0 ) process_slice(zslice, data);
              }
-             if( data != NULL ) free(data);
+             free(data);
            }
 
     \return

--- a/nifti2/nifti_tool.c
+++ b/nifti2/nifti_tool.c
@@ -2285,7 +2285,8 @@ int act_add_exts( nt_opts * opts )
          }
 
          /* if extension came from file, free the data */
-         if( edata ){ free(edata); edata = NULL; }
+         free(edata);
+         edata = NULL;
       }
 
       if( opts->keep_hist && nifti_add_extension(nim, opts->command,
@@ -2589,7 +2590,7 @@ int remove_ext_list( nifti_image * nim, const char ** elist, int len )
          disp_nifti1_extension("+d removing ext: ",nim->ext_list+ec,-1);
 
       /* delete this data, and shift the list down (yeah, inefficient) */
-      if( nim->ext_list[ec].edata ) free( nim->ext_list[ec].edata );
+      free( nim->ext_list[ec].edata );
 
       /* move anything above down one */
       for( c = ec+1; c < nim->num_ext; c++ )
@@ -3386,7 +3387,7 @@ int act_mod_hdrs( nt_opts * opts )
       /* if all is well, overwrite header in fname dataset */
       (void)write_hdr_to_file(nhdr, fname); /* errors printed in function */
 
-      if( dupname ) free(dupname);
+      free(dupname);
       free(nhdr);
    }
 
@@ -3503,7 +3504,7 @@ int act_mod_hdr2s( nt_opts * opts )
       /* if all is well, overwrite header in fname dataset */
       (void)write_hdr2_to_file(nhdr, fname); /* errors printed in function */
 
-      if( dupname ) free(dupname);
+      free(dupname);
       free(nhdr);
    }
 
@@ -3647,7 +3648,7 @@ int act_swap_hdrs( nt_opts * opts )
       /* if all is well, overwrite header in fname dataset */
       (void)write_hdr_to_file(nhdr, fname); /* errors printed in function */
 
-      if( dupname ) free(dupname);
+      free(dupname);
       free(nhdr);
    }
 
@@ -6699,7 +6700,8 @@ int act_disp_ci( nt_opts * opts )
       if( len64 < 0 || !data )
       {
          fprintf(stderr,"** FAILURE for dataset '%s'\n", nim->fname);
-         if( data ) { free(data); data = NULL; }
+         free(data);
+         data = NULL;
          err++;
       } else if ( len64/nim->nbyper > INT_MAX ) {
          fprintf(stderr,"** %" PRId64 " is too many values to display\n",
@@ -6727,7 +6729,7 @@ int act_disp_ci( nt_opts * opts )
       nifti_image_free(nim);
    }
 
-   if( data ) free(data);
+   free(data);
 
    return 0;
 }
@@ -6974,7 +6976,7 @@ int nt_run_misc_nim_tests(nifti_image * nim)
       printf("== subregion: rv=%" PRId64 ", dptr=%p, data=",
              rval, (void *)dptr);
       if( dptr ) disp_raw_data((char *)dptr, nim->datatype, 1, ' ', 1);
-      if( dptr ) free(dptr);
+      free(dptr);
    }
 
    /* test expansion of ints, as 32-bits, not usually used */
@@ -6983,7 +6985,7 @@ int nt_run_misc_nim_tests(nifti_image * nim)
       const char * istr = "7,4,2..5,11..$";
       ilist = nifti_get_intlist(15, istr);
       printf("= ilist = %p, %d\n", (void *)ilist, ilist?ilist[0]:-1);
-      if( ilist ) free(ilist);
+      free(ilist);
    }
 
    return 0;
@@ -7311,11 +7313,11 @@ static int free_opts_mem( nt_opts * nopt )
 {
     if( !nopt ) return 1;
 
-    if( nopt->elist.list   ) free(nopt->elist.list);
-    if( nopt->etypes.list  ) free(nopt->etypes.list);
-    if( nopt->flist.list   ) free(nopt->flist.list);
-    if( nopt->vlist.list   ) free(nopt->vlist.list);
-    if( nopt->infiles.list ) free(nopt->infiles.list);
+    free(nopt->elist.list);
+    free(nopt->etypes.list);
+    free(nopt->flist.list);
+    free(nopt->vlist.list);
+    free(nopt->infiles.list);
 
     return 0;
 }

--- a/niftilib/nifti1_test.c
+++ b/niftilib/nifti1_test.c
@@ -76,8 +76,8 @@ int main( int argc , char *argv[] )
    if( iarg >= argc ){ nifti_image_infodump(nim); exit(0); }
 
    nim->nifti_type = outmode ;
-   if( nim->fname != NULL ) free(nim->fname) ;
-   if( nim->iname != NULL ) free(nim->iname) ;
+   free(nim->fname) ;
+   free(nim->iname) ;
 
    ll = strlen(argv[iarg]) ;
    tmpstr = nifti_makebasename(argv[iarg]);

--- a/niftilib/nifti1_tool.c
+++ b/niftilib/nifti1_tool.c
@@ -1866,7 +1866,8 @@ int act_add_exts( nt_opts * opts )
          }
 
          /* if extension came from file, free the data */
-         if( edata ){ free(edata); edata = NULL; }
+         free(edata);
+         edata = NULL;
       }
 
       if( opts->keep_hist && nifti_add_extension(nim, opts->command,
@@ -2167,7 +2168,7 @@ int remove_ext_list( nifti_image * nim, const char ** elist, int len )
          disp_nifti1_extension("+d removing ext: ",nim->ext_list+ec,-1);
 
       /* delete this data, and shift the list down (yeah, inefficient) */
-      if( nim->ext_list[ec].edata ) free( nim->ext_list[ec].edata );
+      free( nim->ext_list[ec].edata );
 
       /* move anything above down one */
       for( c = ec+1; c < nim->num_ext; c++ )
@@ -2631,7 +2632,7 @@ int act_mod_hdrs( nt_opts * opts )
       /* if all is well, overwrite header in fname dataset */
       (void)write_hdr_to_file(nhdr, fname); /* errors printed in function */
 
-      if( dupname ) free(dupname);
+      free(dupname);
       free(nhdr);
    }
 
@@ -2750,7 +2751,7 @@ int act_swap_hdrs( nt_opts * opts )
       /* if all is well, overwrite header in fname dataset */
       (void)write_hdr_to_file(nhdr, fname); /* errors printed in function */
 
-      if( dupname ) free(dupname);
+      free(dupname);
       free(nhdr);
    }
 
@@ -3804,7 +3805,8 @@ int act_disp_ci( nt_opts * opts )
       if( len < 0 || !data )
       {
          fprintf(stderr,"** FAILURE for dataset '%s'\n", nim->fname);
-         if( data ) { free(data); data = NULL; }
+         free(data);
+         data = NULL;
          err++;
       }
 
@@ -3826,7 +3828,7 @@ int act_disp_ci( nt_opts * opts )
       nifti_image_free(nim);
    }
 
-   if( data ) free(data);
+   free(data);
 
    return 0;
 }
@@ -4106,11 +4108,11 @@ static int free_opts_mem( nt_opts * nopt )
 {
     if( !nopt ) return 1;
 
-    if( nopt->elist.list   ) free(nopt->elist.list);
-    if( nopt->etypes.list  ) free(nopt->etypes.list);
-    if( nopt->flist.list   ) free(nopt->flist.list);
-    if( nopt->vlist.list   ) free(nopt->vlist.list);
-    if( nopt->infiles.list ) free(nopt->infiles.list);
+    free(nopt->elist.list);
+    free(nopt->etypes.list);
+    free(nopt->flist.list);
+    free(nopt->vlist.list);
+    free(nopt->infiles.list);
 
     return 0;
 }


### PR DESCRIPTION
free()ing NULL has been well-defined to do nothing since C89.

This simplifies the code with no behaviour change.