### PR TITLE
Eliminated duplicate strlen() call, fix strlen() truncation to int

### DIFF
--- a/nifti2/nifti_tool.c
+++ b/nifti2/nifti_tool.c
@@ -3828,14 +3828,16 @@ int modify_all_fields( void * basep, nt_opts * opts, field_s * fields, int flen)
  *----------------------------------------------------------------------*/
 int modify_field(void * basep, field_s * field, const char * data)
 {
-   float   fval;
+   float         fval;
    const char  * posn = data;
-   int     val, max, fc, nchars;
+   int           val, max, fc, nchars;
+   size_t        dataLength;
 
    if( g_debug > 1 )
       fprintf(stderr,"+d modifying field '%s' with '%s'\n", field->name, data);
 
-   if( !data || strlen(data) == 0 )
+   dataLength = data ? strlen(data) : 0;
+   if( dataLength == 0 )
    {
       fprintf(stderr,"** no data for '%s' field modification\n",field->name);
       return 1;
@@ -3991,7 +3993,7 @@ int modify_field(void * basep, field_s * field, const char * data)
          case NT_DT_STRING:
          {
             char * dest = (char *)basep + field->offset;
-            nchars = strlen(data);
+            nchars = dataLength;
             strncpy(dest, data, field->len);
             if( nchars < field->len )  /* clear the rest */
                memset(dest+nchars, '\0', field->len-nchars);

--- a/niftilib/nifti1_tool.c
+++ b/niftilib/nifti1_tool.c
@@ -2896,11 +2896,13 @@ int modify_field(void * basep, field_s * field, const char * data)
    float         fval;
    const char  * posn = data;
    int           val, max, fc, nchars;
+   size_t        dataLength;
 
    if( g_debug > 1 )
       fprintf(stderr,"+d modifying field '%s' with '%s'\n", field->name, data);
 
-   if( !data || strlen(data) == 0 )
+   dataLength = data ? strlen(data) : 0;
+   if( dataLength == 0 )
    {
       fprintf(stderr,"** no data for '%s' field modification\n",field->name);
       return 1;
@@ -3015,7 +3017,7 @@ int modify_field(void * basep, field_s * field, const char * data)
          case NT_DT_STRING:
          {
             char * dest = (char *)basep + field->offset;
-            nchars = strlen(data);
+            nchars = dataLength;
             strncpy(dest, data, field->len);
             if( nchars < field->len )  /* clear the rest */
                memset(dest+nchars, '\0', field->len-nchars);


### PR DESCRIPTION
strlen() is O(N) and thus slow for long strings. modify_field() always calls strlen() at the beginning, but was sometimes calling it again later. No need to compute the length twice.

Also use size_t for the return value of strlen() instead of truncating to int.