### PR TITLE
Make opts const, allowing literal parameter.

### DIFF
--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -5248,7 +5248,7 @@ nifti_image* nifti_convert_n2hdr2nim(nifti_2_header nhdr, const char * fname)
         <br>NULL if something fails badly.
     \sa nifti_image_load, nifti_image_free
  */
-znzFile nifti_image_open(const char * hname, char * opts, nifti_image ** nim)
+znzFile nifti_image_open(const char * hname, const char * opts, nifti_image ** nim)
 {
   znzFile fptr=NULL;
   /* open the hdr and reading it in, but do not load the data  */

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -496,7 +496,7 @@ int    valid_nifti_brick_list(nifti_image * nim , int64_t nbricks,
                               const int64_t * blist, int disp_error);
 
 /* znzFile operations */
-znzFile nifti_image_open(const char * hname, char * opts, nifti_image ** nim);
+znzFile nifti_image_open(const char * hname, const char * opts, nifti_image ** nim);
 znzFile nifti_image_write_hdr_img(nifti_image *nim, int write_data,
                                   const char* opts);
 znzFile nifti_image_write_hdr_img2( nifti_image *nim , int write_opts ,


### PR DESCRIPTION
The following code currently fails compile because function parameter `opts` is declared as non-const, disallowing literal constants.

```
	nifti_image* img = NULL;
	znzFile file = nifti_image_open("image.nii", "rb", &img);
```