### PR TITLE
Add support for building as shared library in msvc

### DIFF
--- a/cifti/CMakeLists.txt
+++ b/cifti/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries( ${NIFTI_CIFTILIB_NAME} PUBLIC EXPAT::EXPAT ${NIFTI_PACKAG
 # Set lib version when buildung shared libs.
 if(BUILD_SHARED_LIBS)
     set_target_properties(${NIFTI_CIFTILIB_NAME} PROPERTIES ${NIFTI_LIBRARY_PROPERTIES})
+    target_compile_definitions(${NIFTI_CIFTILIB_NAME} PRIVATE CIFTI_BUILD_SHARED)
+    target_compile_definitions(${NIFTI_CIFTILIB_NAME} INTERFACE CIFTI_USE_SHARED)
 endif()
 install_nifti_target(${NIFTI_CIFTILIB_NAME})
 

--- a/cifti/afni_xml_io.h
+++ b/cifti/afni_xml_io.h
@@ -51,25 +51,27 @@
  * ----------------------------------------------------------------------*/
 
 #ifndef CIF_API
-  #if defined(_WIN32) || defined(__CYGWIN__)
-    #if defined(CIFTI_BUILD_SHARED)
+   #if defined(_WIN32) || defined(__CYGWIN__)
+      #if defined(CIFTI_BUILD_SHARED)
       #ifdef __GNUC__
-        #define CIF_API __attribute__ ((dllexport))
+         #define CIF_API __attribute__ ((dllexport))
       #else
-        #define CIF_API __declspec((dllexport))
+         #define CIF_API __declspec( dllexport )
       #endif
-    #elif defined(CIFTI_USE_SHARED)
+      #elif defined(CIFTI_USE_SHARED)
       #ifdef __GNUC__
-        #define CIF_API __attribute__ ((dllimport))
+         #define CIF_API __attribute__ ((dllimport))
       #else
-        #define CIF_API __declspec((dllimport))
+         #define CIF_API __declspec( dllimport )
       #endif
-    #endif
-  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
-    #define CIF_API __attribute__ ((visibility ("default")))
-  #else
-    #define CIF_API
-  #endif
+      #else
+      #define CIF_API
+      #endif
+   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+      #define CIF_API __attribute__ ((visibility ("default")))
+   #else
+      #define CIF_API
+   #endif
 #endif
 
 /* --------------------------- structures --------------------------------- */

--- a/cifti/afni_xml_io.h
+++ b/cifti/afni_xml_io.h
@@ -5,6 +5,16 @@
 #include <stdio.h>
 #include "afni_xml.h"
 
+#if !defined(CIF_API) && defined(_WIN32) 
+#if defined(CIFTI_BUILD_SHARED)
+#define CIF_API __declspec( dllexport )
+#elif defined(CIFTI_USE_SHARED)
+#define CIF_API __declspec( dllimport )
+#else
+#define CIF_API
+#endif
+#endif
+
 /* ----------------------------------------------------------------------
    CIFTI XML structure:
 
@@ -56,20 +66,20 @@
 
 /* --------------------------- prototypes --------------------------------- */
 
-int axio_read_cifti_file(const char * fname, int get_ndata,
-                         nifti_image ** nim_out, afni_xml_t ** ax_out);
+CIF_API int axio_read_cifti_file(const char * fname, int get_ndata,
+                                 nifti_image ** nim_out, afni_xml_t ** ax_out);
 
-afni_xml_t * axio_cifti_from_ext(nifti_image * nim);
-afni_xml_t * axio_read_buf (const char * buf, int64_t blen);
-afni_xml_t * axio_read_file(const char * fname);
+CIF_API afni_xml_t * axio_cifti_from_ext(nifti_image * nim);
+CIF_API afni_xml_t * axio_read_buf (const char * buf, int64_t blen);
+CIF_API afni_xml_t * axio_read_file(const char * fname);
 
-afni_xml_t * axio_find_map_name(afni_xml_t * ax, const char * name, int maxd);
+CIF_API afni_xml_t * axio_find_map_name(afni_xml_t * ax, const char * name, int maxd);
 
-int axio_text_to_binary (afni_xml_t * ax);
-int axio_num_tokens     (const char * str, int64_t maxlen);
+CIF_API int axio_text_to_binary (afni_xml_t * ax);
+CIF_API int axio_num_tokens     (const char * str, int64_t maxlen);
 
-int axio_show_cifti_summary(FILE * fp, char * mesg, afni_xml_t * ax, int verb);
-int axio_show_mim_summary(FILE * fp, const char * mesg, afni_xml_t * ax, int verb);
-int axio_show_attrs(FILE * fp, afni_xml_t * ax, int indent);
+CIF_API int axio_show_cifti_summary(FILE * fp, char * mesg, afni_xml_t * ax, int verb);
+CIF_API int axio_show_mim_summary(FILE * fp, const char * mesg, afni_xml_t * ax, int verb);
+CIF_API int axio_show_attrs(FILE * fp, afni_xml_t * ax, int indent);
 
 #endif /* AFNI_XML_IO_H */

--- a/cifti/afni_xml_io.h
+++ b/cifti/afni_xml_io.h
@@ -5,16 +5,6 @@
 #include <stdio.h>
 #include "afni_xml.h"
 
-#if !defined(CIF_API) && defined(_WIN32) 
-#if defined(CIFTI_BUILD_SHARED)
-#define CIF_API __declspec( dllexport )
-#elif defined(CIFTI_USE_SHARED)
-#define CIF_API __declspec( dllimport )
-#else
-#define CIF_API
-#endif
-#endif
-
 /* ----------------------------------------------------------------------
    CIFTI XML structure:
 
@@ -59,6 +49,28 @@
 
     - convert as in SUMA_Create_Fake_CIFTI()
  * ----------------------------------------------------------------------*/
+
+#ifndef CIF_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(CIFTI_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define CIF_API __attribute__ ((dllexport))
+      #else
+        #define CIF_API __declspec((dllexport))
+      #endif
+    #elif defined(CIFTI_USE_SHARED)
+      #ifdef __GNUC__
+        #define CIF_API __attribute__ ((dllimport))
+      #else
+        #define CIF_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define CIF_API __attribute__ ((visibility ("default")))
+  #else
+    #define CIF_API
+  #endif
+#endif
 
 /* --------------------------- structures --------------------------------- */
 

--- a/fsliolib/CMakeLists.txt
+++ b/fsliolib/CMakeLists.txt
@@ -13,4 +13,6 @@ target_link_libraries( ${NIFTI_FSLIOLIB_NAME} PUBLIC ${NIFTI_PACKAGE_PREFIX}nift
 # Set lib version when buildung shared libs.
 if(BUILD_SHARED_LIBS)
   set_target_properties(${NIFTI_FSLIOLIB_NAME} PROPERTIES ${NIFTI_LIBRARY_PROPERTIES})
+  target_compile_definitions(${NIFTI_FSLIOLIB_NAME} PRIVATE NIFTI_FSL_BUILD_SHARED)
+  target_compile_definitions(${NIFTI_FSLIOLIB_NAME} INTERFACE NIFTI_FSL_USE_SHARED)
 endif()

--- a/fsliolib/fslio.h
+++ b/fsliolib/fslio.h
@@ -29,6 +29,16 @@
 #include "znzlib.h"
 #include "dbh.h"
 
+#if !defined(FSL_API) && defined(_WIN32) 
+#if defined(NIFTI_FSL_BUILD_SHARED)
+#define FSL_API __declspec( dllexport )
+#elif defined(NIFTI_FSL_USE_SHARED)
+#define FSL_API __declspec( dllimport )
+#else
+#define FSL_API
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -137,109 +147,109 @@ typedef struct
 
   /* basic file i/o commands */
 
-FSLIO *FslOpen(const char *filename, const char *opts);
-FSLIO *FslXOpen(const char *filename, const char *opts, int filetype);
-int FslSeekVolume(FSLIO *fslio, size_t vols);
-int FslClose(FSLIO *fslio);
+FSL_API FSLIO *FslOpen(const char *filename, const char *opts);
+FSL_API FSLIO *FslXOpen(const char *filename, const char *opts, int filetype);
+FSL_API int FslSeekVolume(FSLIO *fslio, size_t vols);
+FSL_API int FslClose(FSLIO *fslio);
 
   /* basic read and write commands */
 
-void* FslReadAllVolumes(FSLIO* fslio, char* filename);
-void  FslWriteAllVolumes(FSLIO *fslio, const void *buffer);
+FSL_API void* FslReadAllVolumes(FSLIO* fslio, char* filename);
+FSL_API void  FslWriteAllVolumes(FSLIO *fslio, const void *buffer);
 
-size_t FslReadVolumes(FSLIO *fslio, void *buffer, size_t nvols);
-size_t FslWriteVolumes(FSLIO *fslio, const void *buffer, size_t nvols);
+FSL_API size_t FslReadVolumes(FSLIO *fslio, void *buffer, size_t nvols);
+FSL_API size_t FslWriteVolumes(FSLIO *fslio, const void *buffer, size_t nvols);
 
-void   FslWriteHeader(FSLIO *fslio);
+FSL_API void   FslWriteHeader(FSLIO *fslio);
 
   /* support functions for file names and types */
 
-int   FslFileExists(const char *filename);
-char *FslMakeBaseName(const char *fname);
-int   FslCheckForMultipleFileNames(const char* filename);
-int   FslGetEnvOutputType(void);
+FSL_API int   FslFileExists(const char *filename);
+FSL_API char *FslMakeBaseName(const char *fname);
+FSL_API int   FslCheckForMultipleFileNames(const char* filename);
+FSL_API int   FslGetEnvOutputType(void);
 
-void  FslSetIgnoreMFQ(int flag);
-int   FslGetIgnoreMFQ(void);
-void  FslSetOverrideOutputType(int type);
-int   FslGetOverrideOutputType(void);
+FSL_API void  FslSetIgnoreMFQ(int flag);
+FSL_API int   FslGetIgnoreMFQ(void);
+FSL_API void  FslSetOverrideOutputType(int type);
+FSL_API int   FslGetOverrideOutputType(void);
 
 
-int  FslGetFileType(const FSLIO *fslio);
-void FslSetFileType(FSLIO *fslio, int filetype);
-int  FslIsSingleFileType(int filetype);
-int  FslIsCompressedFileType(int filetype);
-int  FslBaseFileType(int filetype);
-const char* FslFileTypeString(int filetype);
+FSL_API int  FslGetFileType(const FSLIO *fslio);
+FSL_API void FslSetFileType(FSLIO *fslio, int filetype);
+FSL_API int  FslIsSingleFileType(int filetype);
+FSL_API int  FslIsCompressedFileType(int filetype);
+FSL_API int  FslBaseFileType(int filetype);
+FSL_API const char* FslFileTypeString(int filetype);
 
-int  FslGetWriteMode(const FSLIO *fslio);
-void FslSetWriteMode(FSLIO *fslio, int mode);
+FSL_API int  FslGetWriteMode(const FSLIO *fslio);
+FSL_API void FslSetWriteMode(FSLIO *fslio, int mode);
 
-void AvwSwapHeader(struct dsr *avw);
-int  FslReadRawHeader(void *buffer, const char* filename);
+FSL_API void AvwSwapHeader(struct dsr *avw);
+FSL_API int  FslReadRawHeader(void *buffer, const char* filename);
 
 
   /* simple creation and clone/copy operations */
 
-FSLIO *FslInit(void);
-void   FslInitHeader(FSLIO *fslio, short t,
+FSL_API FSLIO *FslInit(void);
+FSL_API void   FslInitHeader(FSLIO *fslio, short t,
                    size_t x, size_t y, size_t z, size_t v,
                    float vx, float vy, float vz, float tr,
                    size_t dim);
-void   FslSetInit(FSLIO* fslio);
-void   FslCloneHeader(FSLIO *dest, const FSLIO *src);
+FSL_API void   FslSetInit(FSLIO* fslio);
+FSL_API void   FslCloneHeader(FSLIO *dest, const FSLIO *src);
 
 
   /* get and set routines for properties */
 
-size_t FslGetVolSize(FSLIO *fslio);
+FSL_API size_t FslGetVolSize(FSLIO *fslio);
 
-void FslSetDim(FSLIO *fslio, short x, short y, short z, short v);
-void FslGetDim(FSLIO *fslio, short *x, short *y, short *z, short *v);
-void FslSetDimensionality(FSLIO *fslio, size_t dim);
-void FslGetDimensionality(FSLIO *fslio, size_t *dim);
-void FslSetVoxDim(FSLIO *fslio, float x, float y, float z, float tr);
-void FslGetVoxDim(FSLIO *fslio, float *x, float *y, float *z, float *tr);
-void FslGetCalMinMax(FSLIO *fslio, float *min, float *max);
-void FslSetCalMinMax(FSLIO *fslio, float  min, float  max);
-void FslGetAuxFile(FSLIO *fslio,char *aux_file);
-void FslSetAuxFile(FSLIO *fslio,const char *aux_file);
-void FslSetTimeUnits(FSLIO *fslio, const char *units);
-void FslGetTimeUnits(FSLIO *fslio, char *units);
-void FslSetDataType(FSLIO *fslio, short t);
-size_t FslGetDataType(FSLIO *fslio, short *t);
-int    FslGetIntensityScaling(FSLIO *fslio, float *slope, float *intercept);
-void   FslSetIntent(FSLIO *fslio, short intent_code, float p1, float p2, float p3);
-short  FslGetIntent(FSLIO *fslio, short *intent_code, float *p1, float *p2,
-                    float *p3);
+FSL_API void FslSetDim(FSLIO *fslio, short x, short y, short z, short v);
+FSL_API void FslGetDim(FSLIO *fslio, short *x, short *y, short *z, short *v);
+FSL_API void FslSetDimensionality(FSLIO *fslio, size_t dim);
+FSL_API void FslGetDimensionality(FSLIO *fslio, size_t *dim);
+FSL_API void FslSetVoxDim(FSLIO *fslio, float x, float y, float z, float tr);
+FSL_API void FslGetVoxDim(FSLIO *fslio, float *x, float *y, float *z, float *tr);
+FSL_API void FslGetCalMinMax(FSLIO *fslio, float *min, float *max);
+FSL_API void FslSetCalMinMax(FSLIO *fslio, float  min, float  max);
+FSL_API void FslGetAuxFile(FSLIO *fslio,char *aux_file);
+FSL_API void FslSetAuxFile(FSLIO *fslio,const char *aux_file);
+FSL_API void FslSetTimeUnits(FSLIO *fslio, const char *units);
+FSL_API void FslGetTimeUnits(FSLIO *fslio, char *units);
+FSL_API void FslSetDataType(FSLIO *fslio, short t);
+FSL_API size_t FslGetDataType(FSLIO *fslio, short *t);
+FSL_API int    FslGetIntensityScaling(FSLIO *fslio, float *slope, float *intercept);
+FSL_API void   FslSetIntent(FSLIO *fslio, short intent_code, float p1, float p2, float p3);
+FSL_API short  FslGetIntent(FSLIO *fslio, short *intent_code, float *p1, float *p2,
+                            float *p3);
 
 
-short FslGetStdXform(FSLIO *fslio, mat44 *stdmat);
-void  FslSetStdXform(FSLIO *fslio, short sform_code, mat44 stdmat);
-void  FslGetMMCoord(mat44 stdmat, float voxx, float voxy, float voxz,
-                    float *mmx, float *mmy, float *mmz);
+FSL_API short FslGetStdXform(FSLIO *fslio, mat44 *stdmat);
+FSL_API void  FslSetStdXform(FSLIO *fslio, short sform_code, mat44 stdmat);
+FSL_API void  FslGetMMCoord(mat44 stdmat, float voxx, float voxy, float voxz,
+                            float *mmx, float *mmy, float *mmz);
 
-void  FslGetVoxCoord(mat44 stdmat, float mmx, float mmy, float mmz,
-                     float *voxx, float *voxy, float *voxz);
-short FslGetRigidXform(FSLIO *fslio, mat44 *rigidmat);
-void  FslSetRigidXform(FSLIO *fslio, short qform_code, mat44 rigidmat);
-int   FslGetLeftRightOrder(FSLIO *fslio);
+FSL_API void  FslGetVoxCoord(mat44 stdmat, float mmx, float mmy, float mmz,
+                             float *voxx, float *voxy, float *voxz);
+FSL_API short FslGetRigidXform(FSLIO *fslio, mat44 *rigidmat);
+FSL_API void  FslSetRigidXform(FSLIO *fslio, short qform_code, mat44 rigidmat);
+FSL_API int   FslGetLeftRightOrder(FSLIO *fslio);
 
   /* these two functions are deprecated with the nifti/analyze support */
   /* please do all spatial coordinate origins via the Std and Rigid Xforms */
-void  FslSetAnalyzeSform(FSLIO *fslio, const short *orig,
-                         float dx, float dy, float dz);
-void  FslGetAnalyzeOrigin(FSLIO *fslio, short orig[5]);
+FSL_API void  FslSetAnalyzeSform(FSLIO *fslio, const short *orig,
+                                 float dx, float dy, float dz);
+FSL_API void  FslGetAnalyzeOrigin(FSLIO *fslio, short orig[5]);
 
   /* other read and write commands */
 
-size_t FslReadSliceSeries(FSLIO *fslio, void *buffer,short slice, size_t nvols);
-size_t FslReadRowSeries(FSLIO *fslio, void *buffer, short row, short slice, size_t nvols);
-size_t FslReadTimeSeries(FSLIO *fslio, void *buffer, short xVox, short yVox, short zVox, size_t nvols);
+FSL_API size_t FslReadSliceSeries(FSLIO *fslio, void *buffer,short slice, size_t nvols);
+FSL_API size_t FslReadRowSeries(FSLIO *fslio, void *buffer, short row, short slice, size_t nvols);
+FSL_API size_t FslReadTimeSeries(FSLIO *fslio, void *buffer, short xVox, short yVox, short zVox, size_t nvols);
 
   /* miscellaneous helper stuff */
 
-mat33 mat44_to_mat33(mat44 x);
+FSL_API mat33 mat44_to_mat33(mat44 x);
 
 
 
@@ -255,12 +265,12 @@ typedef long            THIS_INT64;
 typedef float           THIS_FLOAT32;
 typedef double          THIS_FLOAT64;
 
-FSLIO * FslReadHeader(char *fname);
-double ****FslGetBufferAsScaledDouble(FSLIO *fslio);
-double ***FslGetVolumeAsScaledDouble(FSLIO *fslio, int vol);
-int  convertBufferToScaledDouble(double *outbuf, void *inbuf, long len, float slope, float inter, int nifti_datatype ) ;
-double ****d4matrix(int th, int zh,  int yh, int xh);
-double ***d3matrix(int zh,  int yh, int xh);
+FSL_API FSLIO * FslReadHeader(char *fname);
+FSL_API double ****FslGetBufferAsScaledDouble(FSLIO *fslio);
+FSL_API double ***FslGetVolumeAsScaledDouble(FSLIO *fslio, int vol);
+FSL_API int  convertBufferToScaledDouble(double *outbuf, void *inbuf, long len, float slope, float inter, int nifti_datatype ) ;
+FSL_API double ****d4matrix(int th, int zh,  int yh, int xh);
+FSL_API double ***d3matrix(int zh,  int yh, int xh);
 
 
 #ifdef __cplusplus

--- a/fsliolib/fslio.h
+++ b/fsliolib/fslio.h
@@ -29,14 +29,26 @@
 #include "znzlib.h"
 #include "dbh.h"
 
-#if !defined(FSL_API) && defined(_WIN32) 
-#if defined(NIFTI_FSL_BUILD_SHARED)
-#define FSL_API __declspec( dllexport )
-#elif defined(NIFTI_FSL_USE_SHARED)
-#define FSL_API __declspec( dllimport )
-#else
-#define FSL_API
-#endif
+#ifndef FSL_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTI_FSL_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define FSL_API __attribute__ ((dllexport))
+      #else
+        #define FSL_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTI_FSL_USE_SHARED)
+      #ifdef __GNUC__
+        #define FSL_API __attribute__ ((dllimport))
+      #else
+        #define FSL_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define FSL_API __attribute__ ((visibility ("default")))
+  #else
+    #define FSL_API
+  #endif
 #endif
 
 #ifdef __cplusplus

--- a/fsliolib/fslio.h
+++ b/fsliolib/fslio.h
@@ -35,14 +35,16 @@
       #ifdef __GNUC__
         #define FSL_API __attribute__ ((dllexport))
       #else
-        #define FSL_API __declspec((dllexport))
+        #define FSL_API __declspec( dllexport )
       #endif
     #elif defined(NIFTI_FSL_USE_SHARED)
       #ifdef __GNUC__
         #define FSL_API __attribute__ ((dllimport))
       #else
-        #define FSL_API __declspec((dllimport))
+        #define FSL_API __declspec( dllimport )
       #endif
+    #else
+      #define FSL_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define FSL_API __attribute__ ((visibility ("default")))

--- a/nifti2/CMakeLists.txt
+++ b/nifti2/CMakeLists.txt
@@ -17,6 +17,8 @@ if(BUILD_SHARED_LIBS)
         VERSION ${NIFTI2_VERSION}
         SOVERSION ${NIFTI2_MAJOR_VERSION}
         )
+    target_compile_definitions(${NIFTI_NIFTILIB2_NAME} PRIVATE NIFTI2_BUILD_SHARED)
+    target_compile_definitions(${NIFTI_NIFTILIB2_NAME} INTERFACE NIFTI2_USE_SHARED)
 endif()
 install_nifti_target(${NIFTI_NIFTILIB2_NAME})
 

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -22,6 +22,16 @@
 
 #include "znzlib.h"
 
+#if !defined(NI2_API) && defined(_WIN32) 
+#if defined(NIFTI2_BUILD_SHARED)
+#define NI2_API __declspec( dllexport )
+#elif defined(NIFTI2_USE_SHARED)
+#define NI2_API __declspec( dllimport )
+#else
+#define NI2_API
+#endif
+#endif
+
 /*=================*/
 #ifdef  __cplusplus
 extern "C" {
@@ -378,169 +388,169 @@ typedef struct {
 /*****************************************************************************/
 /*--------------- Prototypes of functions defined in this file --------------*/
 
-char const * nifti_datatype_string   ( int dt ) ;
-char const *nifti_units_string      ( int uu ) ;
-char const *nifti_intent_string     ( int ii ) ;
-char const *nifti_xform_string      ( int xx ) ;
-char const *nifti_slice_string      ( int ss ) ;
-char const *nifti_orientation_string( int ii ) ;
+NI2_API char const * nifti_datatype_string   ( int dt ) ;
+NI2_API char const *nifti_units_string      ( int uu ) ;
+NI2_API char const *nifti_intent_string     ( int ii ) ;
+NI2_API char const *nifti_xform_string      ( int xx ) ;
+NI2_API char const *nifti_slice_string      ( int ss ) ;
+NI2_API char const *nifti_orientation_string( int ii ) ;
 
-int   nifti_is_inttype( int dt ) ;
+NI2_API int   nifti_is_inttype( int dt ) ;
 
-mat44        nifti_mat44_inverse ( mat44 R ) ;
-mat44        nifti_mat44_mul      ( mat44 A , mat44 B );
-nifti_dmat44 nifti_dmat44_inverse( nifti_dmat44 R ) ;
-int          nifti_mat44_to_dmat44(mat44 * fm, nifti_dmat44 * dm);
-int          nifti_dmat44_to_mat44(nifti_dmat44 * dm, mat44 * fm);
-nifti_dmat44 nifti_dmat44_mul     ( nifti_dmat44 A , nifti_dmat44 B );
+NI2_API mat44        nifti_mat44_inverse ( mat44 R ) ;
+NI2_API mat44        nifti_mat44_mul      ( mat44 A , mat44 B );
+NI2_API nifti_dmat44 nifti_dmat44_inverse( nifti_dmat44 R ) ;
+NI2_API int          nifti_mat44_to_dmat44(mat44 * fm, nifti_dmat44 * dm);
+NI2_API int          nifti_dmat44_to_mat44(nifti_dmat44 * dm, mat44 * fm);
+NI2_API nifti_dmat44 nifti_dmat44_mul     ( nifti_dmat44 A , nifti_dmat44 B );
 
 
 
-nifti_dmat33 nifti_dmat33_inverse( nifti_dmat33 R ) ;
-nifti_dmat33 nifti_dmat33_polar  ( nifti_dmat33 A ) ;
-double       nifti_dmat33_rownorm( nifti_dmat33 A ) ;
-double       nifti_dmat33_colnorm( nifti_dmat33 A ) ;
-double       nifti_dmat33_determ ( nifti_dmat33 R ) ;
-nifti_dmat33 nifti_dmat33_mul    ( nifti_dmat33 A , nifti_dmat33 B ) ;
+NI2_API nifti_dmat33 nifti_dmat33_inverse( nifti_dmat33 R ) ;
+NI2_API nifti_dmat33 nifti_dmat33_polar  ( nifti_dmat33 A ) ;
+NI2_API double       nifti_dmat33_rownorm( nifti_dmat33 A ) ;
+NI2_API double       nifti_dmat33_colnorm( nifti_dmat33 A ) ;
+NI2_API double       nifti_dmat33_determ ( nifti_dmat33 R ) ;
+NI2_API nifti_dmat33 nifti_dmat33_mul    ( nifti_dmat33 A , nifti_dmat33 B ) ;
 
-mat33 nifti_mat33_inverse( mat33 R ) ;
-mat33 nifti_mat33_polar  ( mat33 A ) ;
-float nifti_mat33_rownorm( mat33 A ) ;
-float nifti_mat33_colnorm( mat33 A ) ;
-float nifti_mat33_determ ( mat33 R ) ;
-mat33 nifti_mat33_mul    ( mat33 A , mat33 B ) ;
+NI2_API mat33 nifti_mat33_inverse( mat33 R ) ;
+NI2_API mat33 nifti_mat33_polar  ( mat33 A ) ;
+NI2_API float nifti_mat33_rownorm( mat33 A ) ;
+NI2_API float nifti_mat33_colnorm( mat33 A ) ;
+NI2_API float nifti_mat33_determ ( mat33 R ) ;
+NI2_API mat33 nifti_mat33_mul    ( mat33 A , mat33 B ) ;
 
-void  nifti_swap_2bytes ( int64_t n , void *ar ) ;
-void  nifti_swap_4bytes ( int64_t n , void *ar ) ;
-void  nifti_swap_8bytes ( int64_t n , void *ar ) ;
-void  nifti_swap_16bytes( int64_t n , void *ar ) ;
-void  nifti_swap_Nbytes ( int64_t n , int siz , void *ar ) ;
+NI2_API void  nifti_swap_2bytes ( int64_t n , void *ar ) ;
+NI2_API void  nifti_swap_4bytes ( int64_t n , void *ar ) ;
+NI2_API void  nifti_swap_8bytes ( int64_t n , void *ar ) ;
+NI2_API void  nifti_swap_16bytes( int64_t n , void *ar ) ;
+NI2_API void  nifti_swap_Nbytes ( int64_t n , int siz , void *ar ) ;
 
-int    nifti_datatype_is_valid       (int dtype, int for_nifti);
-int    nifti_datatype_from_string    (const char * name);
-const char * nifti_datatype_to_string(int dtype);
-int    nifti_header_version          (const char * buf, size_t nbytes);
+NI2_API int    nifti_datatype_is_valid       (int dtype, int for_nifti);
+NI2_API int    nifti_datatype_from_string    (const char * name);
+NI2_API const char * nifti_datatype_to_string(int dtype);
+NI2_API int    nifti_header_version          (const char * buf, size_t nbytes);
 
-int64_t nifti_get_filesize( const char *pathname ) ;
-void  swap_nifti_header ( void * hdr , int ni_ver ) ;
-void  old_swap_nifti_header( struct nifti_1_header *h , int is_nifti );
-void  nifti_swap_as_analyze( nifti_analyze75 *h );
-void  nifti_swap_as_nifti1( nifti_1_header *h );
-void  nifti_swap_as_nifti2( nifti_2_header *h );
+NI2_API int64_t nifti_get_filesize( const char *pathname ) ;
+NI2_API void  swap_nifti_header ( void * hdr , int ni_ver ) ;
+NI2_API void  old_swap_nifti_header( struct nifti_1_header *h , int is_nifti );
+NI2_API void  nifti_swap_as_analyze( nifti_analyze75 *h );
+NI2_API void  nifti_swap_as_nifti1( nifti_1_header *h );
+NI2_API void  nifti_swap_as_nifti2( nifti_2_header *h );
 
 
 /* main read/write routines */
 
-nifti_image *nifti_image_read_bricks(const char *hname , int64_t nbricks,
+NI2_API nifti_image *nifti_image_read_bricks(const char *hname , int64_t nbricks,
                                const int64_t *blist, nifti_brick_list * NBL);
-int          nifti_image_load_bricks(nifti_image *nim , int64_t nbricks,
+NI2_API int          nifti_image_load_bricks(nifti_image *nim , int64_t nbricks,
                                const int64_t *blist, nifti_brick_list * NBL);
-void         nifti_free_NBL( nifti_brick_list * NBL );
+NI2_API void         nifti_free_NBL( nifti_brick_list * NBL );
 
-nifti_image *nifti_image_read    ( const char *hname , int read_data);
-int          nifti_image_load    ( nifti_image *nim);
-void         nifti_image_unload  ( nifti_image *nim);
-void         nifti_image_free    ( nifti_image *nim);
+NI2_API nifti_image *nifti_image_read    ( const char *hname , int read_data);
+NI2_API int          nifti_image_load    ( nifti_image *nim);
+NI2_API void         nifti_image_unload  ( nifti_image *nim);
+NI2_API void         nifti_image_free    ( nifti_image *nim);
 
-int64_t      nifti_read_collapsed_image( nifti_image * nim,
+NI2_API int64_t      nifti_read_collapsed_image( nifti_image * nim,
                                          const int64_t dims[8], void ** data);
 
-int64_t      nifti_read_subregion_image(nifti_image *nim, const int64_t *start_index,
+NI2_API int64_t      nifti_read_subregion_image(nifti_image *nim, const int64_t *start_index,
                                         const int64_t *region_size, void ** data);
 
-void         nifti_image_write( nifti_image * nim ) ;
-int          nifti_image_write_status( nifti_image *nim ) ;  /* 7 Jun 2022 */
+NI2_API void         nifti_image_write( nifti_image * nim ) ;
+NI2_API int          nifti_image_write_status( nifti_image *nim ) ;  /* 7 Jun 2022 */
 
-void         nifti_image_write_bricks(nifti_image * nim,
+NI2_API void         nifti_image_write_bricks(nifti_image * nim,
                                       const nifti_brick_list * NBL);
-int          nifti_image_write_bricks_status(nifti_image * nim,
+NI2_API int          nifti_image_write_bricks_status(nifti_image * nim,
                                              const nifti_brick_list * NBL);
-void         nifti_image_infodump( const nifti_image * nim ) ;
+NI2_API void         nifti_image_infodump( const nifti_image * nim ) ;
 
-void         nifti_disp_lib_hist( int ver ) ;  /* to display library history */
-void         nifti_disp_lib_version( void ) ;  /* to display library version */
-int          nifti_disp_matrix_orient( const char * mesg, nifti_dmat44 mat );
-int          nifti_disp_type_list( int which );
+NI2_API void         nifti_disp_lib_hist( int ver ) ;  /* to display library history */
+NI2_API void         nifti_disp_lib_version( void ) ;  /* to display library version */
+NI2_API int          nifti_disp_matrix_orient( const char * mesg, nifti_dmat44 mat );
+NI2_API int          nifti_disp_type_list( int which );
 
 
-char *       nifti_image_to_ascii  ( const nifti_image * nim ) ;
-nifti_image *nifti_image_from_ascii( const char * str, int * bytes_read ) ;
+NI2_API char *       nifti_image_to_ascii  ( const nifti_image * nim ) ;
+NI2_API nifti_image *nifti_image_from_ascii( const char * str, int * bytes_read ) ;
 
-int64_t      nifti_get_volsize(const nifti_image *nim) ;
+NI2_API int64_t      nifti_get_volsize(const nifti_image *nim) ;
 
 /* basic file operations */
-int    nifti_set_filenames(nifti_image * nim, const char * prefix, int check,
+NI2_API int    nifti_set_filenames(nifti_image * nim, const char * prefix, int check,
                            int set_byte_order);
-char * nifti_makehdrname  (const char * prefix, int nifti_type, int check,
+NI2_API char * nifti_makehdrname  (const char * prefix, int nifti_type, int check,
                            int comp);
-char * nifti_makeimgname  (const char * prefix, int nifti_type, int check,
+NI2_API char * nifti_makeimgname  (const char * prefix, int nifti_type, int check,
                            int comp);
-int    is_nifti_file      (const char *hname);
-char * nifti_find_file_extension(const char * name);
-int    nifti_is_complete_filename(const char* fname);
-int    nifti_validfilename(const char* fname);
+NI2_API int    is_nifti_file      (const char *hname);
+NI2_API char * nifti_find_file_extension(const char * name);
+NI2_API int    nifti_is_complete_filename(const char* fname);
+NI2_API int    nifti_validfilename(const char* fname);
 
 
-int    disp_nifti_1_header(const char * info, const nifti_1_header * hp ) ;
-int    disp_nifti_2_header( const char * info, const nifti_2_header * hp ) ;
-void   nifti_set_debug_level( int level ) ;
-void   nifti_set_skip_blank_ext( int skip ) ;
-void   nifti_set_allow_upper_fext( int allow ) ;
-int    nifti_get_alter_cifti( void );
-void   nifti_set_alter_cifti( int alter_cifti );
+NI2_API int    disp_nifti_1_header(const char * info, const nifti_1_header * hp ) ;
+NI2_API int    disp_nifti_2_header( const char * info, const nifti_2_header * hp ) ;
+NI2_API void   nifti_set_debug_level( int level ) ;
+NI2_API void   nifti_set_skip_blank_ext( int skip ) ;
+NI2_API void   nifti_set_allow_upper_fext( int allow ) ;
+NI2_API int    nifti_get_alter_cifti( void );
+NI2_API void   nifti_set_alter_cifti( int alter_cifti );
 
-int    nifti_alter_cifti_dims(nifti_image * nim);
+NI2_API int    nifti_alter_cifti_dims(nifti_image * nim);
 
 
-int    valid_nifti_brick_list(nifti_image * nim , int64_t nbricks,
+NI2_API int    valid_nifti_brick_list(nifti_image * nim , int64_t nbricks,
                               const int64_t * blist, int disp_error);
 
 /* znzFile operations */
-znzFile nifti_image_open(const char * hname, const char * opts, nifti_image ** nim);
-znzFile nifti_image_write_hdr_img(nifti_image *nim, int write_data,
+NI2_API znzFile nifti_image_open(const char * hname, const char * opts, nifti_image ** nim);
+NI2_API znzFile nifti_image_write_hdr_img(nifti_image *nim, int write_data,
                                   const char* opts);
-znzFile nifti_image_write_hdr_img2( nifti_image *nim , int write_opts ,
+NI2_API znzFile nifti_image_write_hdr_img2( nifti_image *nim , int write_opts ,
             const char* opts, znzFile imgfile, const nifti_brick_list * NBL);
-int64_t nifti_read_buffer(znzFile fp, void* dataptr, int64_t ntot,
+NI2_API int64_t nifti_read_buffer(znzFile fp, void* dataptr, int64_t ntot,
                          nifti_image *nim);
-int     nifti_write_all_data(znzFile fp, nifti_image * nim,
+NI2_API int     nifti_write_all_data(znzFile fp, nifti_image * nim,
                              const nifti_brick_list * NBL);
-int64_t  nifti_write_buffer(znzFile fp, const void * buffer, int64_t numbytes);
-nifti_image *nifti_read_ascii_image(znzFile fp, const char *fname, int flen,
+NI2_API int64_t  nifti_write_buffer(znzFile fp, const void * buffer, int64_t numbytes);
+NI2_API nifti_image *nifti_read_ascii_image(znzFile fp, const char *fname, int flen,
                          int read_data);
-znzFile nifti_write_ascii_image(nifti_image *nim, const nifti_brick_list * NBL,
+NI2_API znzFile nifti_write_ascii_image(nifti_image *nim, const nifti_brick_list * NBL,
                          const char * opts, int write_data, int leave_open);
 
 
-void nifti_datatype_sizes( int datatype , int *nbyper, int *swapsize ) ;
+NI2_API void nifti_datatype_sizes( int datatype , int *nbyper, int *swapsize ) ;
 
-void nifti_dmat44_to_quatern(nifti_dmat44 R ,
-                             double *qb, double *qc, double *qd,
-                             double *qx, double *qy, double *qz,
-                             double *dx, double *dy, double *dz, double *qfac);
+NI2_API void nifti_dmat44_to_quatern(nifti_dmat44 R ,
+                                     double *qb, double *qc, double *qd,
+                                     double *qx, double *qy, double *qz,
+                                     double *dx, double *dy, double *dz, double *qfac);
 
-nifti_dmat44 nifti_quatern_to_dmat44( double qb, double qc, double qd,
+NI2_API nifti_dmat44 nifti_quatern_to_dmat44( double qb, double qc, double qd,
                              double qx, double qy, double qz,
                              double dx, double dy, double dz, double qfac );
 
-nifti_dmat44 nifti_make_orthog_dmat44( double r11, double r12, double r13 ,
+NI2_API nifti_dmat44 nifti_make_orthog_dmat44( double r11, double r12, double r13 ,
                                  double r21, double r22, double r23 ,
                                  double r31, double r32, double r33  ) ;
 
-void nifti_mat44_to_quatern( mat44 R ,
+NI2_API void nifti_mat44_to_quatern( mat44 R ,
                              float *qb, float *qc, float *qd,
                              float *qx, float *qy, float *qz,
                              float *dx, float *dy, float *dz, float *qfac ) ;
 
-mat44 nifti_quatern_to_mat44( float qb, float qc, float qd,
+NI2_API mat44 nifti_quatern_to_mat44( float qb, float qc, float qd,
                               float qx, float qy, float qz,
                               float dx, float dy, float dz, float qfac );
 
-mat44 nifti_make_orthog_mat44( float r11, float r12, float r13 ,
+NI2_API mat44 nifti_make_orthog_mat44( float r11, float r12, float r13 ,
                                float r21, float r22, float r23 ,
                                float r31, float r32, float r33  ) ;
 
-int nifti_short_order(void) ;              /* CPU byte order */
+NI2_API int nifti_short_order(void) ;              /* CPU byte order */
 
 
 /* Orientation codes that might be returned from nifti_mat44_to_orientation().*/
@@ -552,60 +562,60 @@ int nifti_short_order(void) ;              /* CPU byte order */
 #define NIFTI_I2S  5    /* Inferior to Superior  */
 #define NIFTI_S2I  6    /* Superior to Inferior  */
 
-void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod ) ;
-void nifti_dmat44_to_orientation( nifti_dmat44 R,
+NI2_API void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod ) ;
+NI2_API void nifti_dmat44_to_orientation( nifti_dmat44 R,
                                   int *icod, int *jcod, int *kcod ) ;
 
 /*--------------------- Low level IO routines ------------------------------*/
 
-char * nifti_findhdrname (const char* fname);
-char * nifti_findimgname (const char* fname , int nifti_type);
-int    nifti_is_gzfile   (const char* fname);
+NI2_API char * nifti_findhdrname (const char* fname);
+NI2_API char * nifti_findimgname (const char* fname , int nifti_type);
+NI2_API int    nifti_is_gzfile   (const char* fname);
 
-char * nifti_makebasename(const char* fname);
+NI2_API char * nifti_makebasename(const char* fname);
 
 
 /* other routines */
-int   nifti_convert_nim2n1hdr(const nifti_image* nim, nifti_1_header * hdr);
-int   nifti_convert_nim2n2hdr(const nifti_image* nim, nifti_2_header * hdr);
-nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[], int arg_dtype);
-nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[], int arg_dtype);
-void           * nifti_read_header(const char *hname, int *nver,    int check);
-nifti_1_header * nifti_read_n1_hdr(const char *hname, int *swapped, int check);
-nifti_2_header * nifti_read_n2_hdr(const char *hname, int *swapped, int check);
-nifti_image    * nifti_copy_nim_info(const nifti_image * src);
-nifti_image    * nifti_make_new_nim(const int64_t dims[], int datatype,
+NI2_API int   nifti_convert_nim2n1hdr(const nifti_image* nim, nifti_1_header * hdr);
+NI2_API int   nifti_convert_nim2n2hdr(const nifti_image* nim, nifti_2_header * hdr);
+NI2_API nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[], int arg_dtype);
+NI2_API nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[], int arg_dtype);
+NI2_API void           * nifti_read_header(const char *hname, int *nver,    int check);
+NI2_API nifti_1_header * nifti_read_n1_hdr(const char *hname, int *swapped, int check);
+NI2_API nifti_2_header * nifti_read_n2_hdr(const char *hname, int *swapped, int check);
+NI2_API nifti_image    * nifti_copy_nim_info(const nifti_image * src);
+NI2_API nifti_image    * nifti_make_new_nim(const int64_t dims[], int datatype,
                                     int data_fill);
 
 
-nifti_image    * nifti_simple_init_nim(void);
-nifti_image    * nifti_convert_n1hdr2nim(nifti_1_header nhdr,const char *fname);
-nifti_image    * nifti_convert_n2hdr2nim(nifti_2_header nhdr,const char *fname);
+NI2_API nifti_image    * nifti_simple_init_nim(void);
+NI2_API nifti_image    * nifti_convert_n1hdr2nim(nifti_1_header nhdr,const char *fname);
+NI2_API nifti_image    * nifti_convert_n2hdr2nim(nifti_2_header nhdr,const char *fname);
 
-int    nifti_looks_like_cifti(nifti_image * nim);
+NI2_API int    nifti_looks_like_cifti(nifti_image * nim);
 
-int    nifti_hdr1_looks_good       (const nifti_1_header * hdr);
-int    nifti_hdr2_looks_good       (const nifti_2_header * hdr);
-int    nifti_is_valid_datatype     (int dtype);
-int    nifti_is_valid_ecode        (int ecode);
-int    nifti_nim_is_valid          (nifti_image * nim, int complain);
-int    nifti_nim_has_valid_dims    (nifti_image * nim, int complain);
-int    is_valid_nifti_type         (int nifti_type);
-int    nifti_test_datatype_sizes   (int verb);
-int    nifti_type_and_names_match  (nifti_image * nim, int show_warn);
-int    nifti_update_dims_from_array(nifti_image * nim);
-void   nifti_set_iname_offset      (nifti_image *nim, int nifti_ver);
-int    nifti_set_type_from_names   (nifti_image * nim);
-int    nifti_add_extension(nifti_image * nim, const char * data, int len,
+NI2_API int    nifti_hdr1_looks_good       (const nifti_1_header * hdr);
+NI2_API int    nifti_hdr2_looks_good       (const nifti_2_header * hdr);
+NI2_API int    nifti_is_valid_datatype     (int dtype);
+NI2_API int    nifti_is_valid_ecode        (int ecode);
+NI2_API int    nifti_nim_is_valid          (nifti_image * nim, int complain);
+NI2_API int    nifti_nim_has_valid_dims    (nifti_image * nim, int complain);
+NI2_API int    is_valid_nifti_type         (int nifti_type);
+NI2_API int    nifti_test_datatype_sizes   (int verb);
+NI2_API int    nifti_type_and_names_match  (nifti_image * nim, int show_warn);
+NI2_API int    nifti_update_dims_from_array(nifti_image * nim);
+NI2_API void   nifti_set_iname_offset      (nifti_image *nim, int nifti_ver);
+NI2_API int    nifti_set_type_from_names   (nifti_image * nim);
+NI2_API int    nifti_add_extension(nifti_image * nim, const char * data, int len,
                            int ecode );
-int    nifti_compiled_with_zlib    (void);
-int    nifti_copy_extensions (nifti_image *nim_dest,const nifti_image *nim_src);
-int    nifti_free_extensions (nifti_image *nim);
-int64_t * nifti_get_int64list(int64_t nvals , const char *str);
-int     * nifti_get_intlist  (int nvals , const char *str);
-char * nifti_strdup          (const char *str);
-int    valid_nifti_extensions(const nifti_image *nim);
-int    nifti_valid_header_size(int ni_ver, int whine);
+NI2_API int    nifti_compiled_with_zlib    (void);
+NI2_API int    nifti_copy_extensions (nifti_image *nim_dest,const nifti_image *nim_src);
+NI2_API int    nifti_free_extensions (nifti_image *nim);
+NI2_API int64_t * nifti_get_int64list(int64_t nvals , const char *str);
+NI2_API int     * nifti_get_intlist  (int nvals , const char *str);
+NI2_API char * nifti_strdup          (const char *str);
+NI2_API int    valid_nifti_extensions(const nifti_image *nim);
+NI2_API int    nifti_valid_header_size(int ni_ver, int whine);
 
 
 /*-------------------- Some C convenience macros ----------------------------*/

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -22,14 +22,26 @@
 
 #include "znzlib.h"
 
-#if !defined(NI2_API) && defined(_WIN32) 
-#if defined(NIFTI2_BUILD_SHARED)
-#define NI2_API __declspec( dllexport )
-#elif defined(NIFTI2_USE_SHARED)
-#define NI2_API __declspec( dllimport )
-#else
-#define NI2_API
-#endif
+#ifndef NI2_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTI2_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define NI2_API __attribute__ ((dllexport))
+      #else
+        #define NI2_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTI2_USE_SHARED)
+      #ifdef __GNUC__
+        #define NI2_API __attribute__ ((dllimport))
+      #else
+        #define NI2_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define NI2_API __attribute__ ((visibility ("default")))
+  #else
+    #define NI2_API
+  #endif
 #endif
 
 /*=================*/

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -28,14 +28,16 @@
       #ifdef __GNUC__
         #define NI2_API __attribute__ ((dllexport))
       #else
-        #define NI2_API __declspec((dllexport))
+        #define NI2_API __declspec( dllexport )
       #endif
     #elif defined(NIFTI2_USE_SHARED)
       #ifdef __GNUC__
         #define NI2_API __attribute__ ((dllimport))
       #else
-        #define NI2_API __declspec((dllimport))
+        #define NI2_API __declspec( dllimport )
       #endif
+    #else
+      #define NI2_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define NI2_API __attribute__ ((visibility ("default")))

--- a/nifti2/nifti_tool.h
+++ b/nifti2/nifti_tool.h
@@ -9,14 +9,16 @@
       #ifdef __GNUC__
         #define NI2_API __attribute__ ((dllexport))
       #else
-        #define NI2_API __declspec((dllexport))
+        #define NI2_API __declspec( dllexport )
       #endif
     #elif defined(NIFTI2_USE_SHARED)
       #ifdef __GNUC__
         #define NI2_API __attribute__ ((dllimport))
       #else
-        #define NI2_API __declspec((dllimport))
+        #define NI2_API __declspec( dllimport )
       #endif
+    #else
+      #define NI2_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define NI2_API __attribute__ ((visibility ("default")))

--- a/nifti2/nifti_tool.h
+++ b/nifti2/nifti_tool.h
@@ -3,14 +3,26 @@
 
 #define NT_CMD_LEN 2048
 
-#if !defined(NI2_API) && defined(_WIN32) 
-#if defined(NIFTI2_BUILD_SHARED)
-#define NI2_API __declspec( dllexport )
-#elif defined(NIFTI2_USE_SHARED)
-#define NI2_API __declspec( dllimport )
-#else
-#define NI2_API
-#endif
+#ifndef NI2_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTI2_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define NI2_API __attribute__ ((dllexport))
+      #else
+        #define NI2_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTI2_USE_SHARED)
+      #ifdef __GNUC__
+        #define NI2_API __attribute__ ((dllimport))
+      #else
+        #define NI2_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define NI2_API __attribute__ ((visibility ("default")))
+  #else
+    #define NI2_API
+  #endif
 #endif
 
 typedef struct{

--- a/nifti2/nifti_tool.h
+++ b/nifti2/nifti_tool.h
@@ -3,6 +3,16 @@
 
 #define NT_CMD_LEN 2048
 
+#if !defined(NI2_API) && defined(_WIN32) 
+#if defined(NIFTI2_BUILD_SHARED)
+#define NI2_API __declspec( dllexport )
+#elif defined(NIFTI2_USE_SHARED)
+#define NI2_API __declspec( dllimport )
+#else
+#define NI2_API
+#endif
+#endif
+
 typedef struct{
    int     len;
    const char ** list;
@@ -230,83 +240,83 @@ typedef struct {
 /*----------------------------------------------------------------------*/
 /*-----  prototypes  ---------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-int    act_add_exts   ( nt_opts * opts );
-int    act_cbl        ( nt_opts * opts );  /* copy brick list */
-int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
-int    act_copy       ( nt_opts * opts );  /* straight library copy */
-int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
-int    act_diff_hdrs  ( nt_opts * opts );
-int    act_diff_hdr1s ( nt_opts * opts );
-int    act_diff_hdr2s ( nt_opts * opts );
-int    act_diff_nims  ( nt_opts * opts );
-int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
-int    act_disp_exts  ( nt_opts * opts );
-int    act_disp_cext  ( nt_opts * opts );
-int    act_disp_hdr   ( nt_opts * opts );
-int    act_disp_hdr1  ( nt_opts * opts );
-int    act_disp_hdr2  ( nt_opts * opts );
-int    act_disp_nims  ( nt_opts * opts );
-int    act_disp_anas  ( nt_opts * opts );
-int    act_disp_ts    ( nt_opts * opts );  /* display time series */
-int    act_mod_hdrs   ( nt_opts * opts );
-int    act_mod_hdr2s  ( nt_opts * opts );
-int    act_mod_nims   ( nt_opts * opts );
-int    act_swap_hdrs  ( nt_opts * opts );
-int    act_rm_ext     ( nt_opts * opts );
-int    act_run_misc_tests( nt_opts * opts );
-int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
+NI2_API int    act_add_exts   ( nt_opts * opts );
+NI2_API int    act_cbl        ( nt_opts * opts );  /* copy brick list */
+NI2_API int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
+NI2_API int    act_copy       ( nt_opts * opts );  /* straight library copy */
+NI2_API int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
+NI2_API int    act_diff_hdrs  ( nt_opts * opts );
+NI2_API int    act_diff_hdr1s ( nt_opts * opts );
+NI2_API int    act_diff_hdr2s ( nt_opts * opts );
+NI2_API int    act_diff_nims  ( nt_opts * opts );
+NI2_API int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
+NI2_API int    act_disp_exts  ( nt_opts * opts );
+NI2_API int    act_disp_cext  ( nt_opts * opts );
+NI2_API int    act_disp_hdr   ( nt_opts * opts );
+NI2_API int    act_disp_hdr1  ( nt_opts * opts );
+NI2_API int    act_disp_hdr2  ( nt_opts * opts );
+NI2_API int    act_disp_nims  ( nt_opts * opts );
+NI2_API int    act_disp_anas  ( nt_opts * opts );
+NI2_API int    act_disp_ts    ( nt_opts * opts );  /* display time series */
+NI2_API int    act_mod_hdrs   ( nt_opts * opts );
+NI2_API int    act_mod_hdr2s  ( nt_opts * opts );
+NI2_API int    act_mod_nims   ( nt_opts * opts );
+NI2_API int    act_swap_hdrs  ( nt_opts * opts );
+NI2_API int    act_rm_ext     ( nt_opts * opts );
+NI2_API int    act_run_misc_tests( nt_opts * opts );
+NI2_API int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
 
 
-field_s * get_hdr1_field( const char * fname, int show_fail );
-field_s * get_hdr2_field( const char * fname, int show_fail );
-field_s * get_nim_field( const char * fname, int show_fail );
-const char    * field_type_str (int type);
+NI2_API field_s * get_hdr1_field( const char * fname, int show_fail );
+NI2_API field_s * get_hdr2_field( const char * fname, int show_fail );
+NI2_API field_s * get_nim_field( const char * fname, int show_fail );
+NI2_API const char    * field_type_str (int type);
 
-int diff_hdr1s    (nifti_1_header *s0, nifti_1_header *s1, int display);
-int diff_hdr1s_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
-                    int display);
-int diff_hdr2s    (nifti_2_header *s0, nifti_2_header *s1, int display);
-int diff_hdr2s_list(nifti_2_header *s0, nifti_2_header *s1, str_list *slist,
-                    int display);
-int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
-int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
+NI2_API int diff_hdr1s    (nifti_1_header *s0, nifti_1_header *s1, int display);
+NI2_API int diff_hdr1s_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
+                            int display);
+NI2_API int diff_hdr2s    (nifti_2_header *s0, nifti_2_header *s1, int display);
+NI2_API int diff_hdr2s_list(nifti_2_header *s0, nifti_2_header *s1, str_list *slist,
+                            int display);
+NI2_API int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
+NI2_API int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
 
-int add_int          (int_list * ilist, int val);
-int add_string       (str_list * slist, const char * str);
-int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
-int clear_float_zeros( char * str );
-int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
-int disp_cifti_extension ( const char *mesg, nifti1_extension * ext, int maxlen);
-int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
-int disp_field       (const char *mesg,field_s *fieldp,void *str,int nfields,int header);
-int disp_field_s_list(const char * mesg, field_s *, int nfields);
-int disp_nt_opts     ( const char *mesg, nt_opts * opts);
-int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
-int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
-int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
-int fill_hdr1_field_array(field_s * nh_fields);
-int fill_hdr2_field_array(field_s * nh_fields);
-int fill_nim1_field_array(field_s * nim_fields);
-int fill_nim2_field_array(field_s * nim_fields);
-int fill_ana_field_array(field_s * ah_fields);
-int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
-int modify_field     (void * basep, field_s * field, const char * data);
-int process_opts     (int argc, char * argv[], nt_opts * opts);
-int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
-int usage            (char * prog, int level);
-int use_full         (void);
-int verify_opts      (nt_opts * opts, char * prog);
-int write_hdr_to_file (nifti_1_header * nhdr, const char * fname);
-int write_hdr2_to_file(nifti_2_header * nhdr, const char * fname);
+NI2_API int add_int          (int_list * ilist, int val);
+NI2_API int add_string       (str_list * slist, const char * str);
+NI2_API int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
+NI2_API int clear_float_zeros( char * str );
+NI2_API int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
+NI2_API int disp_cifti_extension ( const char *mesg, nifti1_extension * ext, int maxlen);
+NI2_API int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
+NI2_API int disp_field       (const char *mesg,field_s *fieldp,void *str,int nfields,int header);
+NI2_API int disp_field_s_list(const char * mesg, field_s *, int nfields);
+NI2_API int disp_nt_opts     ( const char *mesg, nt_opts * opts);
+NI2_API int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
+NI2_API int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
+NI2_API int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
+NI2_API int fill_hdr1_field_array(field_s * nh_fields);
+NI2_API int fill_hdr2_field_array(field_s * nh_fields);
+NI2_API int fill_nim1_field_array(field_s * nim_fields);
+NI2_API int fill_nim2_field_array(field_s * nim_fields);
+NI2_API int fill_ana_field_array(field_s * ah_fields);
+NI2_API int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
+NI2_API int modify_field     (void * basep, field_s * field, const char * data);
+NI2_API int process_opts     (int argc, char * argv[], nt_opts * opts);
+NI2_API int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
+NI2_API int usage            (char * prog, int level);
+NI2_API int use_full         (void);
+NI2_API int verify_opts      (nt_opts * opts, char * prog);
+NI2_API int write_hdr_to_file (nifti_1_header * nhdr, const char * fname);
+NI2_API int write_hdr2_to_file(nifti_2_header * nhdr, const char * fname);
 
 
 /* wrappers for nifti reading functions (allow MAKE_IM) */
-nifti_image    * nt_image_read (nt_opts * opts, const char * fname,
-                                int read_data, int make_ver);
-nifti_image    * nt_read_bricks(nt_opts * opts, char * fname, int len,
-                                int64_t * list, nifti_brick_list * NBL);
-void * nt_read_header(const char * fname, int * nver, int * swapped, int check,
-                      int new_datatype, int64_t new_dim[8]);
+NI2_API nifti_image    * nt_image_read (nt_opts * opts, const char * fname,
+                                        int read_data, int make_ver);
+NI2_API nifti_image    * nt_read_bricks(nt_opts * opts, char * fname, int len,
+                                        int64_t * list, nifti_brick_list * NBL);
+NI2_API void * nt_read_header(const char * fname, int * nver, int * swapped, int check,
+                              int new_datatype, int64_t new_dim[8]);
 
 /* prototypes associated with data conversion */
 static int convert_datatype(nifti_image * nim, nifti_brick_list * NBL,
@@ -323,7 +333,7 @@ static int type_is_signed(int dtype);
 
 
 /* misc functions */
-int           nt_run_misc_nim_tests (nifti_image * nim);
+NI2_API int           nt_run_misc_nim_tests (nifti_image * nim);
 static int    nt_disp_mat44_orient(const char * mesg, mat44 mat);
 static int    nt_test_dmat44_quatern(nifti_image * nim);
 static double dmat44_max_fabs(nifti_dmat44 m);

--- a/nifticdf/CMakeLists.txt
+++ b/nifticdf/CMakeLists.txt
@@ -17,6 +17,8 @@ if(BUILD_SHARED_LIBS)
         VERSION ${NIFTICDF_VERSION}
         SOVERSION ${NIFTICDF_MAJOR_VERSION}
         )
+    target_compile_definitions(${NIFTI_CDFLIB_NAME} PRIVATE NIFTICDF_BUILD_SHARED)
+    target_compile_definitions(${NIFTI_CDFLIB_NAME} INTERFACE NIFTICDF_USE_SHARED)
 endif()
 install_nifti_target(${NIFTI_CDFLIB_NAME})
 if(NIFTI_BUILD_APPLICATIONS)

--- a/nifticdf/nifticdf.h
+++ b/nifticdf/nifticdf.h
@@ -62,14 +62,16 @@
       #ifdef __GNUC__
         #define NCDF_API __attribute__ ((dllexport))
       #else
-        #define NCDF_API __declspec((dllexport))
+        #define NCDF_API __declspec( dllexport )
       #endif
     #elif defined(NIFTICDF_USE_SHARED)
       #ifdef __GNUC__
         #define NCDF_API __attribute__ ((dllimport))
       #else
-        #define NCDF_API __declspec((dllimport))
+        #define NCDF_API __declspec( dllimport )
       #endif
+    #else
+      #define NCDF_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define NCDF_API __attribute__ ((visibility ("default")))

--- a/nifticdf/nifticdf.h
+++ b/nifticdf/nifticdf.h
@@ -56,14 +56,26 @@
      NIFTI_INTENT_LOG10PVAL  = -log10(p)
 *****************************************************************************/
 
-#if !defined(NCDF_API) && defined(_WIN32) 
-#if defined(NIFTICDF_BUILD_SHARED)
-#define NCDF_API __declspec( dllexport )
-#elif defined(NIFTICDF_USE_SHARED)
-#define NCDF_API __declspec( dllimport )
-#else
-#define NCDF_API
-#endif
+#ifndef NCDF_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTICDF_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define NCDF_API __attribute__ ((dllexport))
+      #else
+        #define NCDF_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTICDF_USE_SHARED)
+      #ifdef __GNUC__
+        #define NCDF_API __attribute__ ((dllimport))
+      #else
+        #define NCDF_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define NCDF_API __attribute__ ((visibility ("default")))
+  #else
+    #define NCDF_API
+  #endif
 #endif
 
 NCDF_API extern char const * const inam[];

--- a/nifticdf/nifticdf.h
+++ b/nifticdf/nifticdf.h
@@ -56,120 +56,130 @@
      NIFTI_INTENT_LOG10PVAL  = -log10(p)
 *****************************************************************************/
 
-extern char const * const inam[];
+#if !defined(NCDF_API) && defined(_WIN32) 
+#if defined(NIFTICDF_BUILD_SHARED)
+#define NCDF_API __declspec( dllexport )
+#elif defined(NIFTICDF_USE_SHARED)
+#define NCDF_API __declspec( dllimport )
+#else
+#define NCDF_API
+#endif
+#endif
 
-int nifti_intent_code( char *name );
-double nifti_stat2cdf( double val, int code, double p1,double p2,double p3 );
-double nifti_stat2rcdf( double val, int code, double p1,double p2,double p3 );
-double nifti_cdf2stat( double p , int code, double p1,double p2,double p3 );
+NCDF_API extern char const * const inam[];
+
+NCDF_API int nifti_intent_code( char *name );
+NCDF_API double nifti_stat2cdf( double val, int code, double p1,double p2,double p3 );
+NCDF_API double nifti_stat2rcdf( double val, int code, double p1,double p2,double p3 );
+NCDF_API double nifti_cdf2stat( double p , int code, double p1,double p2,double p3 );
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-double nifti_rcdf2stat( double q , int code, double p1,double p2,double p3 );
+NCDF_API double nifti_rcdf2stat( double q , int code, double p1,double p2,double p3 );
 #endif/*(__COMPILE_UNUSED_FUNCTIONS__)*/
-double nifti_stat2zscore( double val , int code, double p1,double p2,double p3);
-double nifti_stat2hzscore( double val, int code, double p1,double p2,double p3);
+NCDF_API double nifti_stat2zscore( double val , int code, double p1,double p2,double p3);
+NCDF_API double nifti_stat2hzscore( double val, int code, double p1,double p2,double p3);
 
 /** Prototypes for cdflib functions **/
 
-double algdiv(const double*,const double*);
-double alngam(const double*);
-double alnrel(const double*);
-double apser(const double*,double*,const double*,const double*);
-double basym(double*,double*,const double*,const double*);
-double bcorr(const double*,const double*);
-double betaln(const double*,const double*);
-double bfrac(double*,double*,double*,double*,const double*,const double*);
-void bgrat(double*,double*,const double*,const double*,double*,double*,int*ierr);
-double bpser(double*,double*,const double*,const double*);
-void bratio(const double*,const double*,const double*,const double*,double*,double*,int*);
-double brcmp1(int*,double*,double*,const double*,const double*);
-double brcomp(double*,double*,const double*,const double*);
-double bup(double*,double*,double*,double*,const int*,const double*);
-void cdfbet(const int*,double*,double*,double*,double*,double*,double*,
-                   int*,double*);
-void cdfbin(const int*,double*,double*,double*,double*,double*,double*,
-                   int*,double*);
-void cdfchi(const int*,double*,double*,double*,double*,int*,double*);
-void cdfchn(const int*,double*,double*,double*,double*,double*,int*,double*);
-void cdff(const int*,double*,double*,double*,double*,double*,int*,double*);
-void cdffnc(const int*,double*,double*,double*,double*,double*,double*,
-                   int*status,double*);
-void cdfgam(const int*,double*,double*,double*,double*,double*,int*,double*);
+NCDF_API double algdiv(const double*,const double*);
+NCDF_API double alngam(const double*);
+NCDF_API double alnrel(const double*);
+NCDF_API double apser(const double*,double*,const double*,const double*);
+NCDF_API double basym(double*,double*,const double*,const double*);
+NCDF_API double bcorr(const double*,const double*);
+NCDF_API double betaln(const double*,const double*);
+NCDF_API double bfrac(double*,double*,double*,double*,const double*,const double*);
+NCDF_API void bgrat(double*,double*,const double*,const double*,double*,double*,int*ierr);
+NCDF_API double bpser(double*,double*,const double*,const double*);
+NCDF_API void bratio(const double*,const double*,const double*,const double*,double*,double*,int*);
+NCDF_API double brcmp1(int*,double*,double*,const double*,const double*);
+NCDF_API double brcomp(double*,double*,const double*,const double*);
+NCDF_API double bup(double*,double*,double*,double*,const int*,const double*);
+NCDF_API void cdfbet(const int*,double*,double*,double*,double*,double*,double*,
+                            int*,double*);
+NCDF_API void cdfbin(const int*,double*,double*,double*,double*,double*,double*,
+                            int*,double*);
+NCDF_API void cdfchi(const int*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cdfchn(const int*,double*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cdff(const int*,double*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cdffnc(const int*,double*,double*,double*,double*,double*,double*,
+                            int*status,double*);
+NCDF_API void cdfgam(const int*,double*,double*,double*,double*,double*,int*,double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-void cdfnbn(int*,double*,double*,double*,double*,double*,double*,
-                   int*,double*);
-void cdfnor(int*,double*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cdfnbn(int*,double*,double*,double*,double*,double*,double*,
+NCDF_API                    int*,double*);
+NCDF_API void cdfnor(int*,double*,double*,double*,double*,double*,int*,double*);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
-void cdfpoi(const int*,double*,double*,double*,double*,int*,double*);
-void cdft(const int*,double*,double*,double*,double*,int*,double*);
-void cumbet(double*,double*,double*,double*,double*,double*);
-void cumbin(const double*,const double*,double*,double*,double*,double*);
-void cumchi(const double*,const double*,double*,double*);
-void cumchn(double*,double*,const double*,double*,double*);
-void cumf(const double*,const double*,const double*,double*,double*);
-void cumfnc(double*,double*,double*,const double*,double*,double*);
-void cumgam(double*,double*,double*,double*);
+NCDF_API void cdfpoi(const int*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cdft(const int*,double*,double*,double*,double*,int*,double*);
+NCDF_API void cumbet(double*,double*,double*,double*,double*,double*);
+NCDF_API void cumbin(const double*,const double*,double*,double*,double*,double*);
+NCDF_API void cumchi(const double*,const double*,double*,double*);
+NCDF_API void cumchn(double*,double*,const double*,double*,double*);
+NCDF_API void cumf(const double*,const double*,const double*,double*,double*);
+NCDF_API void cumfnc(double*,double*,double*,const double*,double*,double*);
+NCDF_API void cumgam(double*,double*,double*,double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-void cumnbn(double*,double*,double*,double*,double*,double*);
+NCDF_API void cumnbn(double*,double*,double*,double*,double*,double*);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
-void cumnor(const double*,double*,double*);
-void cumpoi(const double*,const double*,double*,double*);
-void cumt(const double*,const double*,double*,double*);
+NCDF_API void cumnor(const double*,double*,double*);
+NCDF_API void cumpoi(const double*,const double*,double*,double*);
+NCDF_API void cumt(const double*,const double*,double*,double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-double dbetrm(double*,double*);
+NCDF_API double dbetrm(double*,double*);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
-double devlpl(const double [],const int*,const double*);
+NCDF_API double devlpl(const double [],const int*,const double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-double dexpm1(double*);
-double dinvnr(const double *p,const double *q);
+NCDF_API double dexpm1(double*);
+NCDF_API double dinvnr(const double *p,const double *q);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
-void E0000(int,int*,double*,double*,unsigned long*,
-                  unsigned long*,const double*,const double*,const double*,
-                  const double*,const double*,const double*,const double*);
-void dinvr(int*,double*,double*,unsigned long*,unsigned long*);
-void dstinv(double*,double*,double*,double*,double*,double*,
-                   double*);
+NCDF_API void E0000(int,int*,double*,double*,unsigned long*,
+                           unsigned long*,const double*,const double*,const double*,
+                           const double*,const double*,const double*,const double*);
+NCDF_API void dinvr(int*,double*,double*,unsigned long*,unsigned long*);
+NCDF_API void dstinv(double*,double*,double*,double*,double*,double*,
+                             double*);
 #if defined(__COMPILE_UNUSED_FUNCTIONS__)
-double dlanor(double*);
-double dln1mx(double*);
-double dln1px(double*);
-double dlnbet(double*,double*);
-double dlngam(double*);
-double dstrem(double*);
+NCDF_API double dlanor(double*);
+NCDF_API double dln1mx(double*);
+NCDF_API double dln1px(double*);
+NCDF_API double dlnbet(double*,double*);
+NCDF_API double dlngam(double*);
+NCDF_API double dstrem(double*);
 #endif /*defined(__COMPILE_UNUSED_FUNCTIONS__)*/
-double dt1(double*,double*,const double*);
-void E0001(int,int*,double*,const double*,double*,double*,
-                  unsigned long*,unsigned long*,const double*,const double*,
-                  const double*,const double*);
-void dzror(int*,double*,double*,double*,double *,
-                  unsigned long*,unsigned long*);
-void dstzr(double *zxlo,double *zxhi,double *zabstl,double *zreltl);
-double erf1(const double*);
-double erfc1(const int*,const double*);
-double esum(const int*,const double*);
-double exparg(const int*);
-double fpser(const double*,const double*,const double*,const double*);
-double gam1(const double*);
-void gaminv(double*,double*,const double*,const double*,const double*,int*);
-double gamln(double*);
-double gamln1(const double*);
-double Xgamm(const double*);
-void grat1(double*,const double*,const double*,double*,double*,const double*);
-void gratio(double*,const double*,double*,double*,const int*);
-double gsumln(const double*,const double*);
-double psi(const double*);
-double rcomp(double*,const double*);
-double rexp(const double*);
-double rlog(const double*);
-double rlog1(const double*);
-double spmpar(const int*);
-double stvaln(const double*);
-double fifdint(double);
-double fifdmax1(double,double);
-double fifdmin1(double,double);
-double fifdsign(double,double);
-long fifidint(double);
-long fifmod(long,long);
-void ftnstop(const char*);
-int ipmpar(const int*);
+NCDF_API double dt1(double*,double*,const double*);
+NCDF_API void E0001(int,int*,double*,const double*,double*,double*,
+                           unsigned long*,unsigned long*,const double*,const double*,
+                           const double*,const double*);
+NCDF_API void dzror(int*,double*,double*,double*,double *,
+                           unsigned long*,unsigned long*);
+NCDF_API void dstzr(double *zxlo,double *zxhi,double *zabstl,double *zreltl);
+NCDF_API double erf1(const double*);
+NCDF_API double erfc1(const int*,const double*);
+NCDF_API double esum(const int*,const double*);
+NCDF_API double exparg(const int*);
+NCDF_API double fpser(const double*,const double*,const double*,const double*);
+NCDF_API double gam1(const double*);
+NCDF_API void gaminv(double*,double*,const double*,const double*,const double*,int*);
+NCDF_API double gamln(double*);
+NCDF_API double gamln1(const double*);
+NCDF_API double Xgamm(const double*);
+NCDF_API void grat1(double*,const double*,const double*,double*,double*,const double*);
+NCDF_API void gratio(double*,const double*,double*,double*,const int*);
+NCDF_API double gsumln(const double*,const double*);
+NCDF_API double psi(const double*);
+NCDF_API double rcomp(double*,const double*);
+NCDF_API double rexp(const double*);
+NCDF_API double rlog(const double*);
+NCDF_API double rlog1(const double*);
+NCDF_API double spmpar(const int*);
+NCDF_API double stvaln(const double*);
+NCDF_API double fifdint(double);
+NCDF_API double fifdmax1(double,double);
+NCDF_API double fifdmin1(double,double);
+NCDF_API double fifdsign(double,double);
+NCDF_API long fifidint(double);
+NCDF_API long fifmod(long,long);
+NCDF_API void ftnstop(const char*);
+NCDF_API int ipmpar(const int*);
 
 /** end: prototypes for cdflib functions **/

--- a/niftilib/CMakeLists.txt
+++ b/niftilib/CMakeLists.txt
@@ -17,6 +17,8 @@ if(BUILD_SHARED_LIBS)
         VERSION ${NIFTI_VERSION}
         SOVERSION ${NIFTI_MAJOR_VERSION}
         )
+    target_compile_definitions(${NIFTI_NIFTILIB_NAME} PRIVATE NIFTIIO_BUILD_SHARED)
+    target_compile_definitions(${NIFTI_NIFTILIB_NAME} INTERFACE NIFTIIO_USE_SHARED)
 endif()
 install_nifti_target(${NIFTI_NIFTILIB_NAME})
 

--- a/niftilib/nifti1_io.h
+++ b/niftilib/nifti1_io.h
@@ -19,14 +19,26 @@
 
 #include "znzlib.h"
 
-#if !defined(NIO_API) && defined(_WIN32) 
-#if defined(NIFTIIO_BUILD_SHARED)
-#define NIO_API __declspec( dllexport )
-#elif defined(NIFTIIO_USE_SHARED)
-#define NIO_API __declspec( dllimport )
-#else
-#define NIO_API
-#endif
+#ifndef NIO_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTIIO_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define NIO_API __attribute__ ((dllexport))
+      #else
+        #define NIO_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTIIO_USE_SHARED)
+      #ifdef __GNUC__
+        #define NIO_API __attribute__ ((dllimport))
+      #else
+        #define NIO_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define NIO_API __attribute__ ((visibility ("default")))
+  #else
+    #define NIO_API
+  #endif
 #endif
 
 /*=================*/

--- a/niftilib/nifti1_io.h
+++ b/niftilib/nifti1_io.h
@@ -25,14 +25,16 @@
       #ifdef __GNUC__
         #define NIO_API __attribute__ ((dllexport))
       #else
-        #define NIO_API __declspec((dllexport))
+        #define NIO_API __declspec( dllexport )
       #endif
     #elif defined(NIFTIIO_USE_SHARED)
       #ifdef __GNUC__
         #define NIO_API __attribute__ ((dllimport))
       #else
-        #define NIO_API __declspec((dllimport))
+        #define NIO_API __declspec( dllimport )
       #endif
+    #else
+      #define NIO_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define NIO_API __attribute__ ((visibility ("default")))

--- a/niftilib/nifti1_io.h
+++ b/niftilib/nifti1_io.h
@@ -19,6 +19,16 @@
 
 #include "znzlib.h"
 
+#if !defined(NIO_API) && defined(_WIN32) 
+#if defined(NIFTIIO_BUILD_SHARED)
+#define NIO_API __declspec( dllexport )
+#elif defined(NIFTIIO_USE_SHARED)
+#define NIO_API __declspec( dllimport )
+#else
+#define NIO_API
+#endif
+#endif
+
 /*=================*/
 #ifdef  __cplusplus
 extern "C" {
@@ -244,133 +254,135 @@ typedef struct {
 /*****************************************************************************/
 /*--------------- Prototypes of functions defined in this file --------------*/
 
-char const * nifti_datatype_string   ( int dt ) ;
-char const *nifti_units_string      ( int uu ) ;
-char const *nifti_intent_string     ( int ii ) ;
-char const *nifti_xform_string      ( int xx ) ;
-char const *nifti_slice_string      ( int ss ) ;
-char const *nifti_orientation_string( int ii ) ;
+NIO_API char const * nifti_datatype_string   ( int dt ) ;
+NIO_API char const *nifti_units_string      ( int uu ) ;
+NIO_API char const *nifti_intent_string     ( int ii ) ;
+NIO_API char const *nifti_xform_string      ( int xx ) ;
+NIO_API char const *nifti_slice_string      ( int ss ) ;
+NIO_API char const *nifti_orientation_string( int ii ) ;
 
-int   nifti_is_inttype( int dt ) ;
+NIO_API int   nifti_is_inttype( int dt ) ;
 
-mat44 nifti_mat44_inverse( mat44 R ) ;
+NIO_API mat44 nifti_mat44_inverse( mat44 R ) ;
 
-mat33 nifti_mat33_inverse( mat33 R ) ;
-mat33 nifti_mat33_polar  ( mat33 A ) ;
-float nifti_mat33_rownorm( mat33 A ) ;
-float nifti_mat33_colnorm( mat33 A ) ;
-float nifti_mat33_determ ( mat33 R ) ;
-mat33 nifti_mat33_mul    ( mat33 A , mat33 B ) ;
+NIO_API mat33 nifti_mat33_inverse( mat33 R ) ;
+NIO_API mat33 nifti_mat33_polar  ( mat33 A ) ;
+NIO_API float nifti_mat33_rownorm( mat33 A ) ;
+NIO_API float nifti_mat33_colnorm( mat33 A ) ;
+NIO_API float nifti_mat33_determ ( mat33 R ) ;
+NIO_API mat33 nifti_mat33_mul    ( mat33 A , mat33 B ) ;
 
-void  nifti_swap_2bytes ( size_t n , void *ar ) ;
-void  nifti_swap_4bytes ( size_t n , void *ar ) ;
-void  nifti_swap_8bytes ( size_t n , void *ar ) ;
-void  nifti_swap_16bytes( size_t n , void *ar ) ;
-void  nifti_swap_Nbytes ( size_t n , int siz , void *ar ) ;
+NIO_API void  nifti_swap_2bytes ( size_t n , void *ar ) ;
+NIO_API void  nifti_swap_4bytes ( size_t n , void *ar ) ;
+NIO_API void  nifti_swap_8bytes ( size_t n , void *ar ) ;
+NIO_API void  nifti_swap_16bytes( size_t n , void *ar ) ;
+NIO_API void  nifti_swap_Nbytes ( size_t n , int siz , void *ar ) ;
 
-int    nifti_datatype_is_valid   (int dtype, int for_nifti);
-int    nifti_datatype_from_string(const char * name);
-const char * nifti_datatype_to_string  (int dtype);
+NIO_API int    nifti_datatype_is_valid   (int dtype, int for_nifti);
+NIO_API int    nifti_datatype_from_string(const char * name);
+NIO_API const char * nifti_datatype_to_string  (int dtype);
 
-int   nifti_get_filesize( const char *pathname ) ;
-void  swap_nifti_header ( struct nifti_1_header *h , int is_nifti ) ;
-void  old_swap_nifti_header( struct nifti_1_header *h , int is_nifti );
-int   nifti_swap_as_analyze( nifti_analyze75 *h );
+NIO_API int   nifti_get_filesize( const char *pathname ) ;
+NIO_API void  swap_nifti_header ( struct nifti_1_header *h , int is_nifti ) ;
+NIO_API void  old_swap_nifti_header( struct nifti_1_header *h , int is_nifti );
+NIO_API int   nifti_swap_as_analyze( nifti_analyze75 *h );
 
 
 /* main read/write routines */
 
-nifti_image *nifti_image_read_bricks(const char *hname , int nbricks,
-                                     const int *blist, nifti_brick_list * NBL);
-int          nifti_image_load_bricks(nifti_image *nim , int nbricks,
-                                     const int *blist, nifti_brick_list * NBL);
-void         nifti_free_NBL( nifti_brick_list * NBL );
+NIO_API nifti_image *nifti_image_read_bricks(const char *hname , int nbricks,
+                                             const int *blist, nifti_brick_list * NBL);
+NIO_API int          nifti_image_load_bricks(nifti_image *nim , int nbricks,
+                                             const int *blist, nifti_brick_list * NBL);
+NIO_API void         nifti_free_NBL( nifti_brick_list * NBL );
 
-nifti_image *nifti_image_read    ( const char *hname , int read_data ) ;
-int          nifti_image_load    ( nifti_image *nim ) ;
-void         nifti_image_unload  ( nifti_image *nim ) ;
-void         nifti_image_free    ( nifti_image *nim ) ;
+NIO_API nifti_image *nifti_image_read    ( const char *hname , int read_data ) ;
+NIO_API int          nifti_image_load    ( nifti_image *nim ) ;
+NIO_API void         nifti_image_unload  ( nifti_image *nim ) ;
+NIO_API void         nifti_image_free    ( nifti_image *nim ) ;
 
-int          nifti_read_collapsed_image( nifti_image * nim, const int dims [8],
-                                         void ** data );
+NIO_API int          nifti_read_collapsed_image( nifti_image * nim, const int dims [8],
+                                                 void ** data );
 
-int          nifti_read_subregion_image( nifti_image * nim,
-                                         const int *start_index, const int *region_size,
-                                         void ** data );
+NIO_API int          nifti_read_subregion_image( nifti_image * nim,
+                                                 const int *start_index, const int *region_size,
+                                                 void ** data );
 
-void         nifti_image_write   ( nifti_image * nim ) ;
-int          nifti_image_write_status( nifti_image *nim );
+NIO_API void         nifti_image_write   ( nifti_image * nim ) ;
+NIO_API int          nifti_image_write_status( nifti_image *nim );
 
-void         nifti_image_write_bricks(nifti_image * nim,
-                                      const nifti_brick_list * NBL);
-int          nifti_image_write_bricks_status(nifti_image * nim,
-                                             const nifti_brick_list * NBL);
-void         nifti_image_infodump( const nifti_image * nim ) ;
+NIO_API void         nifti_image_write_bricks(nifti_image * nim,
+                                              const nifti_brick_list * NBL);
+NIO_API int          nifti_image_write_bricks_status(nifti_image * nim,
+                                                     const nifti_brick_list * NBL);
+NIO_API void         nifti_image_infodump( const nifti_image * nim ) ;
 
-void         nifti_disp_lib_hist( void ) ;     /* to display library history */
-void         nifti_disp_lib_version( void ) ;  /* to display library version */
-int          nifti_disp_matrix_orient( const char * mesg, mat44 mat );
-int          nifti_disp_type_list( int which );
+NIO_API void         nifti_disp_lib_hist( void ) ;     /* to display library history */
+NIO_API void         nifti_disp_lib_version( void ) ;  /* to display library version */
+NIO_API int          nifti_disp_matrix_orient( const char * mesg, mat44 mat );
+NIO_API int          nifti_disp_type_list( int which );
 
 
-char *       nifti_image_to_ascii  ( const nifti_image * nim ) ;
-nifti_image *nifti_image_from_ascii( const char * str, int * bytes_read ) ;
+NIO_API char *       nifti_image_to_ascii  ( const nifti_image * nim ) ;
+NIO_API nifti_image *nifti_image_from_ascii( const char * str, int * bytes_read ) ;
 
-size_t       nifti_get_volsize(const nifti_image *nim) ;
+NIO_API size_t       nifti_get_volsize(const nifti_image *nim) ;
 
 /* basic file operations */
-int    nifti_set_filenames(nifti_image * nim, const char * prefix, int check,
-                           int set_byte_order);
-char * nifti_makehdrname  (const char * prefix, int nifti_type, int check,
-                           int comp);
-char * nifti_makeimgname  (const char * prefix, int nifti_type, int check,
-                           int comp);
-int    is_nifti_file      (const char *hname);
-char * nifti_find_file_extension(const char * name);
-int    nifti_is_complete_filename(const char* fname);
-int    nifti_validfilename(const char* fname);
+NIO_API int    nifti_set_filenames( nifti_image * nim, const char * prefix, int check,
+                                    int set_byte_order);
+NIO_API char * nifti_makehdrname  ( const char * prefix, int nifti_type, int check,
+                                    int comp);
+NIO_API char * nifti_makeimgname  ( const char * prefix, int nifti_type, int check,
+                                    int comp);
+NIO_API int    is_nifti_file      ( const char *hname);
+NIO_API char * nifti_find_file_extension( const char * name);
+NIO_API int    nifti_is_complete_filename( const char* fname);
+NIO_API int    nifti_validfilename( const char* fname);
 
-int    disp_nifti_1_header(const char * info, const nifti_1_header * hp ) ;
-void   nifti_set_debug_level( int level ) ;
-void   nifti_set_skip_blank_ext( int skip ) ;
-void   nifti_set_allow_upper_fext( int allow ) ;
+NIO_API int    disp_nifti_1_header(const char * info, const nifti_1_header * hp ) ;
+NIO_API void   nifti_set_debug_level( int level ) ;
+NIO_API void   nifti_set_skip_blank_ext( int skip ) ;
+NIO_API void   nifti_set_allow_upper_fext( int allow ) ;
 
-int    valid_nifti_brick_list(nifti_image * nim , int nbricks,
-                              const int * blist, int disp_error);
+NIO_API int    valid_nifti_brick_list( nifti_image * nim , int nbricks,
+                                       const int * blist, int disp_error);
 
 /* znzFile operations */
-znzFile nifti_image_open(const char * hname, const char * opts, nifti_image ** nim);
-znzFile nifti_image_write_hdr_img(nifti_image *nim, int write_data,
-                                  const char* opts);
-znzFile nifti_image_write_hdr_img2( nifti_image *nim , int write_opts ,
-               const char* opts, znzFile imgfile, const nifti_brick_list * NBL);
-size_t  nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
-                         nifti_image *nim);
-int     nifti_write_all_data(znzFile fp, nifti_image * nim,
-                             const nifti_brick_list * NBL);
-size_t  nifti_write_buffer(znzFile fp, const void * buffer, size_t numbytes);
-nifti_image *nifti_read_ascii_image(znzFile fp, char *fname, int flen,
-                         int read_data);
-znzFile nifti_write_ascii_image(nifti_image *nim, const nifti_brick_list * NBL,
-                         const char * opts, int write_data, int leave_open);
+NIO_API znzFile nifti_image_open( const char * hname, const char * opts, nifti_image ** nim);
+NIO_API znzFile nifti_image_write_hdr_img( nifti_image *nim, int write_data,
+                                           const char* opts);
+NIO_API znzFile nifti_image_write_hdr_img2( nifti_image *nim , int write_opts ,
+                                            const char* opts, znzFile imgfile, 
+                                            const nifti_brick_list * NBL);
+NIO_API size_t  nifti_read_buffer( znzFile fp, void* dataptr, size_t ntot,
+                                   nifti_image *nim);
+NIO_API int     nifti_write_all_data( znzFile fp, nifti_image * nim,
+                                      const nifti_brick_list * NBL);
+NIO_API size_t  nifti_write_buffer( znzFile fp, const void * buffer, size_t numbytes);
+NIO_API nifti_image *nifti_read_ascii_image( znzFile fp, char *fname, int flen,
+                                             int read_data);
+NIO_API znzFile nifti_write_ascii_image( nifti_image *nim, const nifti_brick_list * NBL,
+                                         const char * opts, int write_data, 
+                                         int leave_open);
 
 
-void nifti_datatype_sizes( int datatype , int *nbyper, int *swapsize ) ;
+NIO_API void nifti_datatype_sizes( int datatype , int *nbyper, int *swapsize ) ;
 
-void nifti_mat44_to_quatern( mat44 R ,
-                             float *qb, float *qc, float *qd,
-                             float *qx, float *qy, float *qz,
-                             float *dx, float *dy, float *dz, float *qfac ) ;
+NIO_API void nifti_mat44_to_quatern( mat44 R ,
+                                     float *qb, float *qc, float *qd,
+                                     float *qx, float *qy, float *qz,
+                                     float *dx, float *dy, float *dz, float *qfac ) ;
 
-mat44 nifti_quatern_to_mat44( float qb, float qc, float qd,
-                              float qx, float qy, float qz,
-                              float dx, float dy, float dz, float qfac );
+NIO_API mat44 nifti_quatern_to_mat44( float qb, float qc, float qd,
+                                      float qx, float qy, float qz,
+                                      float dx, float dy, float dz, float qfac );
 
-mat44 nifti_make_orthog_mat44( float r11, float r12, float r13 ,
-                               float r21, float r22, float r23 ,
-                               float r31, float r32, float r33  ) ;
+NIO_API mat44 nifti_make_orthog_mat44( float r11, float r12, float r13 ,
+                                       float r21, float r22, float r23 ,
+                                       float r31, float r32, float r33  ) ;
 
-int nifti_short_order(void) ;              /* CPU byte order */
+NIO_API int nifti_short_order(void) ;              /* CPU byte order */
 
 
 /* Orientation codes that might be returned from nifti_mat44_to_orientation().*/
@@ -382,47 +394,47 @@ int nifti_short_order(void) ;              /* CPU byte order */
 #define NIFTI_I2S  5    /* Inferior to Superior  */
 #define NIFTI_S2I  6    /* Superior to Inferior  */
 
-void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod ) ;
+NIO_API void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod ) ;
 
 /*--------------------- Low level IO routines ------------------------------*/
 
-char * nifti_findhdrname (const char* fname);
-char * nifti_findimgname (const char* fname , int nifti_type);
-int    nifti_is_gzfile   (const char* fname);
+NIO_API char * nifti_findhdrname (const char* fname);
+NIO_API char * nifti_findimgname (const char* fname , int nifti_type);
+NIO_API int    nifti_is_gzfile   (const char* fname);
 
-char * nifti_makebasename(const char* fname);
+NIO_API char * nifti_makebasename(const char* fname);
 
 
 /* other routines */
-struct nifti_1_header   nifti_convert_nim2nhdr(const nifti_image* nim);
-nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype);
-nifti_1_header * nifti_read_header(const char *hname, int *swapped, int check);
-nifti_image    * nifti_copy_nim_info(const nifti_image * src);
-nifti_image    * nifti_make_new_nim(const int dims[], int datatype,
+NIO_API struct nifti_1_header   nifti_convert_nim2nhdr(const nifti_image* nim);
+NIO_API nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype);
+NIO_API nifti_1_header * nifti_read_header(const char *hname, int *swapped, int check);
+NIO_API nifti_image    * nifti_copy_nim_info(const nifti_image * src);
+NIO_API nifti_image    * nifti_make_new_nim(const int dims[], int datatype,
                                                       int data_fill);
-nifti_image    * nifti_simple_init_nim(void);
-nifti_image    * nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
+NIO_API nifti_image    * nifti_simple_init_nim(void);
+NIO_API nifti_image    * nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
                                         const char * fname);
 
-int    nifti_hdr_looks_good        (const nifti_1_header * hdr);
-int    nifti_is_valid_datatype     (int dtype);
-int    nifti_is_valid_ecode        (int ecode);
-int    nifti_nim_is_valid          (nifti_image * nim, int complain);
-int    nifti_nim_has_valid_dims    (nifti_image * nim, int complain);
-int    is_valid_nifti_type         (int nifti_type);
-int    nifti_test_datatype_sizes   (int verb);
-int    nifti_type_and_names_match  (nifti_image * nim, int show_warn);
-int    nifti_update_dims_from_array(nifti_image * nim);
-void   nifti_set_iname_offset      (nifti_image *nim);
-int    nifti_set_type_from_names   (nifti_image * nim);
-int    nifti_add_extension(nifti_image * nim, const char * data, int len,
-                           int ecode );
-int    nifti_compiled_with_zlib    (void);
-int    nifti_copy_extensions (nifti_image *nim_dest,const nifti_image *nim_src);
-int    nifti_free_extensions (nifti_image *nim);
-int  * nifti_get_intlist     (int nvals , const char *str);
-char * nifti_strdup          (const char *str);
-int    valid_nifti_extensions(const nifti_image *nim);
+NIO_API int    nifti_hdr_looks_good        (const nifti_1_header * hdr);
+NIO_API int    nifti_is_valid_datatype     (int dtype);
+NIO_API int    nifti_is_valid_ecode        (int ecode);
+NIO_API int    nifti_nim_is_valid          (nifti_image * nim, int complain);
+NIO_API int    nifti_nim_has_valid_dims    (nifti_image * nim, int complain);
+NIO_API int    is_valid_nifti_type         (int nifti_type);
+NIO_API int    nifti_test_datatype_sizes   (int verb);
+NIO_API int    nifti_type_and_names_match  (nifti_image * nim, int show_warn);
+NIO_API int    nifti_update_dims_from_array(nifti_image * nim);
+NIO_API void   nifti_set_iname_offset      (nifti_image *nim);
+NIO_API int    nifti_set_type_from_names   (nifti_image * nim);
+NIO_API int    nifti_add_extension(nifti_image * nim, const char * data, int len,
+                                   int ecode );
+NIO_API int    nifti_compiled_with_zlib    (void);
+NIO_API int    nifti_copy_extensions (nifti_image *nim_dest,const nifti_image *nim_src);
+NIO_API int    nifti_free_extensions (nifti_image *nim);
+NIO_API int  * nifti_get_intlist     (int nvals , const char *str);
+NIO_API char * nifti_strdup          (const char *str);
+NIO_API int    valid_nifti_extensions(const nifti_image *nim);
 
 
 /*-------------------- Some C convenience macros ----------------------------*/

--- a/niftilib/nifti1_tool.h
+++ b/niftilib/nifti1_tool.h
@@ -3,30 +3,6 @@
 
 #define NT_CMD_LEN 2048
 
-#ifndef NIO_API
-  #if defined(_WIN32) || defined(__CYGWIN__)
-    #if defined(NIFTIIO_BUILD_SHARED)
-      #ifdef __GNUC__
-        #define NIO_API __attribute__ ((dllexport))
-      #else
-        #define NIO_API __declspec( dllexport )
-      #endif
-    #elif defined(NIFTIIO_USE_SHARED)
-      #ifdef __GNUC__
-        #define NIO_API __attribute__ ((dllimport))
-      #else
-        #define NIO_API __declspec( dllimport )
-      #endif
-    #else
-      #define NIO_API
-    #endif
-  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
-    #define NIO_API __attribute__ ((visibility ("default")))
-  #else
-    #define NIO_API
-  #endif
-#endif
-
 typedef struct{
    int           len;
    const char ** list;
@@ -123,65 +99,65 @@ typedef struct {
 /*----------------------------------------------------------------------*/
 /*-----  prototypes  ---------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-NIO_API int    act_add_exts   ( nt_opts * opts );
-NIO_API int    act_cbl        ( nt_opts * opts );  /* copy brick list */
-NIO_API int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
-NIO_API int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
-NIO_API int    act_diff_hdrs  ( nt_opts * opts );
-NIO_API int    act_diff_nims  ( nt_opts * opts );
-NIO_API int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
-NIO_API int    act_disp_exts  ( nt_opts * opts );
-NIO_API int    act_disp_hdrs  ( nt_opts * opts );
-NIO_API int    act_disp_nims  ( nt_opts * opts );
-NIO_API int    act_disp_anas  ( nt_opts * opts );
-NIO_API int    act_disp_ts    ( nt_opts * opts );  /* display time series */
-NIO_API int    act_mod_hdrs   ( nt_opts * opts );
-NIO_API int    act_mod_nims   ( nt_opts * opts );
-NIO_API int    act_swap_hdrs  ( nt_opts * opts );
-NIO_API int    act_rm_ext     ( nt_opts * opts );
-NIO_API int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
+int    act_add_exts   ( nt_opts * opts );
+int    act_cbl        ( nt_opts * opts );  /* copy brick list */
+int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
+int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
+int    act_diff_hdrs  ( nt_opts * opts );
+int    act_diff_nims  ( nt_opts * opts );
+int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
+int    act_disp_exts  ( nt_opts * opts );
+int    act_disp_hdrs  ( nt_opts * opts );
+int    act_disp_nims  ( nt_opts * opts );
+int    act_disp_anas  ( nt_opts * opts );
+int    act_disp_ts    ( nt_opts * opts );  /* display time series */
+int    act_mod_hdrs   ( nt_opts * opts );
+int    act_mod_nims   ( nt_opts * opts );
+int    act_swap_hdrs  ( nt_opts * opts );
+int    act_rm_ext     ( nt_opts * opts );
+int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
 
 
-NIO_API field_s    * get_hdr_field( const char * fname, int show_fail );
-NIO_API field_s    * get_nim_field( const char * fname, int show_fail );
-NIO_API const char * field_type_str (int type);
+field_s    * get_hdr_field( const char * fname, int show_fail );
+field_s    * get_nim_field( const char * fname, int show_fail );
+const char * field_type_str (int type);
 
-NIO_API int diff_hdrs     (nifti_1_header *s0, nifti_1_header *s1, int display);
-NIO_API int diff_hdrs_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
-                               int display);
-NIO_API int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
-NIO_API int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
+int diff_hdrs     (nifti_1_header *s0, nifti_1_header *s1, int display);
+int diff_hdrs_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
+                   int display);
+int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
+int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
 
-NIO_API int add_int          (int_list * ilist, int val);
-NIO_API int add_string       (str_list * slist, const char * str);
-NIO_API int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
-NIO_API int clear_float_zeros( char * str );
-NIO_API int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
-NIO_API int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
-NIO_API int disp_field       ( const char *mesg,field_s *fieldp,void *str,int nfields,int header);
-NIO_API int disp_field_s_list( const char *mesg, field_s *, int nfields);
-NIO_API int disp_nt_opts     ( const char *mesg, nt_opts * opts);
-NIO_API int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
-NIO_API int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
-NIO_API int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
-NIO_API int fill_hdr_field_array(field_s * nh_fields);
-NIO_API int fill_nim_field_array(field_s * nim_fields);
-NIO_API int fill_ana_field_array(field_s * ah_fields);
-NIO_API int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
-NIO_API int modify_field     (void * basep, field_s * field, const char * data);
-NIO_API int process_opts     (int argc, char * argv[], nt_opts * opts);
-NIO_API int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
-NIO_API int usage            (const char * prog, int level);
-NIO_API int use_full         (const char * prog);
-NIO_API int verify_opts      (nt_opts * opts, char * prog);
-NIO_API int write_hdr_to_file(nifti_1_header * nhdr, const char * fname);
+int add_int          (int_list * ilist, int val);
+int add_string       (str_list * slist, const char * str);
+int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
+int clear_float_zeros( char * str );
+int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
+int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
+int disp_field       ( const char *mesg,field_s *fieldp,void *str,int nfields,int header);
+int disp_field_s_list( const char *mesg, field_s *, int nfields);
+int disp_nt_opts     ( const char *mesg, nt_opts * opts);
+int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
+int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
+int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
+int fill_hdr_field_array(field_s * nh_fields);
+int fill_nim_field_array(field_s * nim_fields);
+int fill_ana_field_array(field_s * ah_fields);
+int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
+int modify_field     (void * basep, field_s * field, const char * data);
+int process_opts     (int argc, char * argv[], nt_opts * opts);
+int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
+int usage            (const char * prog, int level);
+int use_full         (const char * prog);
+int verify_opts      (nt_opts * opts, char * prog);
+int write_hdr_to_file(nifti_1_header * nhdr, const char * fname);
 
 /* wrappers for nifti reading functions (allow MAKE_IM) */
-NIO_API nifti_image    * nt_image_read (nt_opts * opts, const char * fname, int doread);
-NIO_API nifti_image    * nt_read_bricks(nt_opts * opts, const char * fname, int len,
-                                            int * list, nifti_brick_list * NBL);
-NIO_API nifti_1_header * nt_read_header(nt_opts * opts, const char * fname, int * swapped,
-                                            int check);
+nifti_image    * nt_image_read (nt_opts * opts, const char * fname, int doread);
+nifti_image    * nt_read_bricks(nt_opts * opts, const char * fname, int len,
+                                int * list, nifti_brick_list * NBL);
+nifti_1_header * nt_read_header(nt_opts * opts, const char * fname, int * swapped,
+                                int check);
 
 
 #endif  /* NIFTI1_TOOL_H */

--- a/niftilib/nifti1_tool.h
+++ b/niftilib/nifti1_tool.h
@@ -3,6 +3,16 @@
 
 #define NT_CMD_LEN 2048
 
+#if !defined(NIO_API) && defined(_WIN32) 
+#if defined(NIFTIIO_BUILD_SHARED)
+#define NIO_API __declspec( dllexport )
+#elif defined(NIFTIIO_USE_SHARED)
+#define NIO_API __declspec( dllimport )
+#else
+#define NIO_API
+#endif
+#endif
+
 typedef struct{
    int           len;
    const char ** list;
@@ -99,65 +109,65 @@ typedef struct {
 /*----------------------------------------------------------------------*/
 /*-----  prototypes  ---------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-int    act_add_exts   ( nt_opts * opts );
-int    act_cbl        ( nt_opts * opts );  /* copy brick list */
-int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
-int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
-int    act_diff_hdrs  ( nt_opts * opts );
-int    act_diff_nims  ( nt_opts * opts );
-int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
-int    act_disp_exts  ( nt_opts * opts );
-int    act_disp_hdrs  ( nt_opts * opts );
-int    act_disp_nims  ( nt_opts * opts );
-int    act_disp_anas  ( nt_opts * opts );
-int    act_disp_ts    ( nt_opts * opts );  /* display time series */
-int    act_mod_hdrs   ( nt_opts * opts );
-int    act_mod_nims   ( nt_opts * opts );
-int    act_swap_hdrs  ( nt_opts * opts );
-int    act_rm_ext     ( nt_opts * opts );
-int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
+NIO_API int    act_add_exts   ( nt_opts * opts );
+NIO_API int    act_cbl        ( nt_opts * opts );  /* copy brick list */
+NIO_API int    act_cci        ( nt_opts * opts );  /* copy collapsed dimensions */
+NIO_API int    act_check_hdrs ( nt_opts * opts );  /* check for valid hdr or nim */
+NIO_API int    act_diff_hdrs  ( nt_opts * opts );
+NIO_API int    act_diff_nims  ( nt_opts * opts );
+NIO_API int    act_disp_ci    ( nt_opts * opts );  /* display general collapsed data */
+NIO_API int    act_disp_exts  ( nt_opts * opts );
+NIO_API int    act_disp_hdrs  ( nt_opts * opts );
+NIO_API int    act_disp_nims  ( nt_opts * opts );
+NIO_API int    act_disp_anas  ( nt_opts * opts );
+NIO_API int    act_disp_ts    ( nt_opts * opts );  /* display time series */
+NIO_API int    act_mod_hdrs   ( nt_opts * opts );
+NIO_API int    act_mod_nims   ( nt_opts * opts );
+NIO_API int    act_swap_hdrs  ( nt_opts * opts );
+NIO_API int    act_rm_ext     ( nt_opts * opts );
+NIO_API int    act_strip      ( nt_opts * opts );  /* strip extras from datasets */
 
 
-field_s    * get_hdr_field( const char * fname, int show_fail );
-field_s    * get_nim_field( const char * fname, int show_fail );
-const char * field_type_str (int type);
+NIO_API field_s    * get_hdr_field( const char * fname, int show_fail );
+NIO_API field_s    * get_nim_field( const char * fname, int show_fail );
+NIO_API const char * field_type_str (int type);
 
-int diff_hdrs     (nifti_1_header *s0, nifti_1_header *s1, int display);
-int diff_hdrs_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
-                   int display);
-int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
-int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
+NIO_API int diff_hdrs     (nifti_1_header *s0, nifti_1_header *s1, int display);
+NIO_API int diff_hdrs_list(nifti_1_header *s0, nifti_1_header *s1, str_list *slist,
+                               int display);
+NIO_API int diff_nims     (nifti_image *s0,nifti_image *s1,        int display);
+NIO_API int diff_nims_list(nifti_image *s0,nifti_image *s1,str_list *slist,int display);
 
-int add_int          (int_list * ilist, int val);
-int add_string       (str_list * slist, const char * str);
-int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
-int clear_float_zeros( char * str );
-int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
-int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
-int disp_field       ( const char *mesg,field_s *fieldp,void *str,int nfields,int header);
-int disp_field_s_list( const char *mesg, field_s *, int nfields);
-int disp_nt_opts     ( const char *mesg, nt_opts * opts);
-int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
-int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
-int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
-int fill_hdr_field_array(field_s * nh_fields);
-int fill_nim_field_array(field_s * nim_fields);
-int fill_ana_field_array(field_s * ah_fields);
-int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
-int modify_field     (void * basep, field_s * field, const char * data);
-int process_opts     (int argc, char * argv[], nt_opts * opts);
-int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
-int usage            (const char * prog, int level);
-int use_full         (const char * prog);
-int verify_opts      (nt_opts * opts, char * prog);
-int write_hdr_to_file(nifti_1_header * nhdr, const char * fname);
+NIO_API int add_int          (int_list * ilist, int val);
+NIO_API int add_string       (str_list * slist, const char * str);
+NIO_API int check_total_size ( const char *mesg, field_s *fields, int nfields, int tot_size);
+NIO_API int clear_float_zeros( char * str );
+NIO_API int diff_field       (field_s *fieldp, void * str0, void * str1, int nfields);
+NIO_API int disp_nifti1_extension( const char *mesg, nifti1_extension * ext, int maxlen);
+NIO_API int disp_field       ( const char *mesg,field_s *fieldp,void *str,int nfields,int header);
+NIO_API int disp_field_s_list( const char *mesg, field_s *, int nfields);
+NIO_API int disp_nt_opts     ( const char *mesg, nt_opts * opts);
+NIO_API int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
+NIO_API int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
+NIO_API int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
+NIO_API int fill_hdr_field_array(field_s * nh_fields);
+NIO_API int fill_nim_field_array(field_s * nim_fields);
+NIO_API int fill_ana_field_array(field_s * ah_fields);
+NIO_API int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
+NIO_API int modify_field     (void * basep, field_s * field, const char * data);
+NIO_API int process_opts     (int argc, char * argv[], nt_opts * opts);
+NIO_API int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
+NIO_API int usage            (const char * prog, int level);
+NIO_API int use_full         (const char * prog);
+NIO_API int verify_opts      (nt_opts * opts, char * prog);
+NIO_API int write_hdr_to_file(nifti_1_header * nhdr, const char * fname);
 
 /* wrappers for nifti reading functions (allow MAKE_IM) */
-nifti_image    * nt_image_read (nt_opts * opts, const char * fname, int doread);
-nifti_image    * nt_read_bricks(nt_opts * opts, const char * fname, int len,
-                                int * list, nifti_brick_list * NBL);
-nifti_1_header * nt_read_header(nt_opts * opts, const char * fname, int * swapped,
-                                int check);
+NIO_API nifti_image    * nt_image_read (nt_opts * opts, const char * fname, int doread);
+NIO_API nifti_image    * nt_read_bricks(nt_opts * opts, const char * fname, int len,
+                                            int * list, nifti_brick_list * NBL);
+NIO_API nifti_1_header * nt_read_header(nt_opts * opts, const char * fname, int * swapped,
+                                            int check);
 
 
 #endif  /* NIFTI1_TOOL_H */

--- a/niftilib/nifti1_tool.h
+++ b/niftilib/nifti1_tool.h
@@ -3,14 +3,26 @@
 
 #define NT_CMD_LEN 2048
 
-#if !defined(NIO_API) && defined(_WIN32) 
-#if defined(NIFTIIO_BUILD_SHARED)
-#define NIO_API __declspec( dllexport )
-#elif defined(NIFTIIO_USE_SHARED)
-#define NIO_API __declspec( dllimport )
-#else
-#define NIO_API
-#endif
+#ifndef NIO_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NIFTIIO_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define NIO_API __attribute__ ((dllexport))
+      #else
+        #define NIO_API __declspec((dllexport))
+      #endif
+    #elif defined(NIFTIIO_USE_SHARED)
+      #ifdef __GNUC__
+        #define NIO_API __attribute__ ((dllimport))
+      #else
+        #define NIO_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define NIO_API __attribute__ ((visibility ("default")))
+  #else
+    #define NIO_API
+  #endif
 #endif
 
 typedef struct{

--- a/niftilib/nifti1_tool.h
+++ b/niftilib/nifti1_tool.h
@@ -9,14 +9,16 @@
       #ifdef __GNUC__
         #define NIO_API __attribute__ ((dllexport))
       #else
-        #define NIO_API __declspec((dllexport))
+        #define NIO_API __declspec( dllexport )
       #endif
     #elif defined(NIFTIIO_USE_SHARED)
       #ifdef __GNUC__
         #define NIO_API __attribute__ ((dllimport))
       #else
-        #define NIO_API __declspec((dllimport))
+        #define NIO_API __declspec( dllimport )
       #endif
+    #else
+      #define NIO_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define NIO_API __attribute__ ((visibility ("default")))

--- a/znzlib/CMakeLists.txt
+++ b/znzlib/CMakeLists.txt
@@ -17,5 +17,7 @@ if(BUILD_SHARED_LIBS)
         VERSION ${ZNZLIB_VERSION}
         SOVERSION ${ZNZLIB_MAJOR_VERSION}
         )
+    target_compile_definitions(${NIFTI_ZNZLIB_NAME} PRIVATE ZNZ_BUILD_SHARED)
+    target_compile_definitions(${NIFTI_ZNZLIB_NAME} INTERFACE ZNZ_USE_SHARED)
 endif()
 install_nifti_target(${NIFTI_ZNZLIB_NAME})

--- a/znzlib/znzlib.h
+++ b/znzlib/znzlib.h
@@ -76,14 +76,26 @@ extern "C" {
 #endif
 #endif
 
-#if !defined(ZNZ_API) && defined(_WIN32) 
-#if defined(ZNZ_BUILD_SHARED)
-#define ZNZ_API __declspec( dllexport )
-#elif defined(ZNZ_USE_SHARED)
-#define ZNZ_API __declspec( dllimport )
-#else
-#define ZNZ_API
-#endif
+#ifndef ZNZ_API
+  #if defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(ZNZ_BUILD_SHARED)
+      #ifdef __GNUC__
+        #define ZNZ_API __attribute__ ((dllexport))
+      #else
+        #define ZNZ_API __declspec((dllexport))
+      #endif
+    #elif defined(ZNZ_USE_SHARED)
+      #ifdef __GNUC__
+        #define ZNZ_API __attribute__ ((dllimport))
+      #else
+        #define ZNZ_API __declspec((dllimport))
+      #endif
+    #endif
+  #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    #define ZNZ_API __attribute__ ((visibility ("default")))
+  #else
+    #define ZNZ_API
+  #endif
 #endif
 
 struct znzptr {

--- a/znzlib/znzlib.h
+++ b/znzlib/znzlib.h
@@ -82,14 +82,16 @@ extern "C" {
       #ifdef __GNUC__
         #define ZNZ_API __attribute__ ((dllexport))
       #else
-        #define ZNZ_API __declspec((dllexport))
+        #define ZNZ_API __declspec( dllexport )
       #endif
     #elif defined(ZNZ_USE_SHARED)
       #ifdef __GNUC__
         #define ZNZ_API __attribute__ ((dllimport))
       #else
-        #define ZNZ_API __declspec((dllimport))
+        #define ZNZ_API __declspec( dllimport )
       #endif
+    #else
+      #define ZNZ_API
     #endif
   #elif (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
     #define ZNZ_API __attribute__ ((visibility ("default")))

--- a/znzlib/znzlib.h
+++ b/znzlib/znzlib.h
@@ -76,6 +76,16 @@ extern "C" {
 #endif
 #endif
 
+#if !defined(ZNZ_API) && defined(_WIN32) 
+#if defined(ZNZ_BUILD_SHARED)
+#define ZNZ_API __declspec( dllexport )
+#elif defined(ZNZ_USE_SHARED)
+#define ZNZ_API __declspec( dllimport )
+#else
+#define ZNZ_API
+#endif
+#endif
+
 struct znzptr {
   int withz;
   FILE* nzfptr;
@@ -98,35 +108,35 @@ typedef struct znzptr * znzFile;
    use_compression!=0 uses zlib (gzip) compression
 */
 
-znzFile znzopen(const char *path, const char *mode, int use_compression);
+ZNZ_API znzFile znzopen(const char *path, const char *mode, int use_compression);
 
 #ifdef COMPILE_NIFTIUNUSED_CODE
-znzFile znzdopen(int fd, const char *mode, int use_compression);
+ZNZ_API znzFile znzdopen(int fd, const char *mode, int use_compression);
 #endif
 
-int Xznzclose(znzFile * file);
+ZNZ_API int Xznzclose(znzFile * file);
 
-size_t znzread(void* buf, size_t size, size_t nmemb, znzFile file);
+ZNZ_API size_t znzread(void* buf, size_t size, size_t nmemb, znzFile file);
 
-size_t znzwrite(const void* buf, size_t size, size_t nmemb, znzFile file);
+ZNZ_API size_t znzwrite(const void* buf, size_t size, size_t nmemb, znzFile file);
 
-znz_off_t znzseek(znzFile file, znz_off_t offset, int whence);
+ZNZ_API znz_off_t znzseek(znzFile file, znz_off_t offset, int whence);
 
-int znzrewind(znzFile stream);
+ZNZ_API int znzrewind(znzFile stream);
 
-znz_off_t znztell(znzFile file);
+ZNZ_API znz_off_t znztell(znzFile file);
 
-int znzputs(const char *str, znzFile file);
+ZNZ_API int znzputs(const char *str, znzFile file);
 
 #ifdef COMPILE_NIFTIUNUSED_CODE
-char * znzgets(char* str, int size, znzFile file);
+ZNZ_API char * znzgets(char* str, int size, znzFile file);
 
-int znzputc(int c, znzFile file);
+ZNZ_API int znzputc(int c, znzFile file);
 
-int znzgetc(znzFile file);
+ZNZ_API int znzgetc(znzFile file);
 
 #if !defined(WIN32)
-int znzprintf(znzFile stream, const char *format, ...);
+ZNZ_API int znzprintf(znzFile stream, const char *format, ...);
 #endif
 #endif
 


### PR DESCRIPTION
Hi :)

This is a "fix" to support building the libraries as shared libraries on msvc. 
This was previously not possible, because msvc requres symbols to be marked for exporting.
Cmake has a "dirty" fix for this: [CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS](https://cmake.org/cmake/help/latest/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html), however this might export too much and also does not work for global variables (such as `inam` in `nifticdf`).

So I added `..._API` defines which turn into either `__declspec( dllexport )` or `__declspec( dllimport )` when building shared libs. 

Let me know what you think of this :)