### PR TITLE
Zlib include fix and CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ if (NIFTI_BUILD_TESTING )
   include(FetchContent) # fetch data a configure time to simplify tests
   # If new or changed data is needed, add that data to the https://github.com/NIFTI-Imaging/nifti-test-data repo
   # make a new release, and then update the URL and hash (shasum -a 256 <downloaded tarball>).
+  cmake_policy(SET CMP0169 OLD)
   FetchContent_Declare( fetch_testing_data
           URL      https://github.com/NIFTI-Imaging/nifti-test-data/archive/v3.0.2.tar.gz
           URL_HASH SHA256=5dafec078151018da7aaf3c941bd31f246f590bc34fa3fef29ce77a773db16a6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set_if_not_defined(NIFTI_INSTALL_ARCHIVE_DIR ${NIFTI_INSTALL_LIBRARY_DIR})
 set_if_not_defined(NIFTI_INSTALL_INCLUDE_DIR include/nifti)
 set_if_not_defined(NIFTI_INSTALL_MAN_DIR share/man/man1)
 set_if_not_defined(NIFTI_INSTALL_DOC_DIR share/doc/${PROJECT_NAME})
+set_if_not_defined(NIFTI_INSTALL_MODULE_DIR share/cmake/${PACKAGE_NAME})
 set_if_not_defined(NIFTI_ZLIB_LIBRARIES "")
 set_if_not_defined(ZNZ_COMPILE_DEF "")
 if(NOT NIFTI_ZLIB_LIBRARIES) # If using a custom zlib library, skip the find package
@@ -241,7 +242,7 @@ if(NIFTI_INSTALL_EXPORT_NAME STREQUAL "NIFTITargets")
   # NIFTI libraries into an external project
   include(CMakePackageConfigHelpers)
   set(CONFIG_SETUP_DIR ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME})
-  set(ConfigPackageLocation share/cmake/${PACKAGE_NAME})
+  set(ConfigPackageLocation ${NIFTI_INSTALL_MODULE_DIR})
 
   write_basic_package_version_file(
         ${CONFIG_SETUP_DIR}/${PACKAGE_NAME}ConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if (NIFTI_BUILD_TESTING )
   FetchContent_Declare( fetch_testing_data
           URL      https://github.com/NIFTI-Imaging/nifti-test-data/archive/v3.0.2.tar.gz
           URL_HASH SHA256=5dafec078151018da7aaf3c941bd31f246f590bc34fa3fef29ce77a773db16a6
+          DOWNLOAD_EXTRACT_TIMESTAMP TRUE
           )
   FetchContent_GetProperties(fetch_testing_data)
   if(NOT fetch_testing_data_POPULATED)

--- a/cmake/nifti_macros.cmake
+++ b/cmake/nifti_macros.cmake
@@ -133,6 +133,9 @@ function(install_nifti_target target_name)
           PUBLIC_HEADER
             DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
             COMPONENT Development
+          PRIVATE_HEADER
+            DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
+            COMPONENT Development
           INCLUDES
             DESTINATION ${NIFTI_INSTALL_INCLUDE_DIR}
           )

--- a/znzlib/CMakeLists.txt
+++ b/znzlib/CMakeLists.txt
@@ -2,6 +2,12 @@ set(NIFTI_ZNZLIB_NAME ${NIFTI_PACKAGE_PREFIX}znz)
 
 add_nifti_library(${NIFTI_ZNZLIB_NAME} znzlib.c )
 target_link_libraries( ${NIFTI_ZNZLIB_NAME} PUBLIC ${NIFTI_ZLIB_LIBRARIES} )
+if(${ZLIB_FOUND})
+  target_include_directories(${NIFTI_ZNZLIB_NAME} PUBLIC
+                            ${ZLIB_INCLUDE_DIR}
+                            )
+
+endif()
 set_target_properties(
   ${NIFTI_ZNZLIB_NAME}
   PROPERTIES


### PR DESCRIPTION
Fix the problem, if ZLIB header is not located in system default search include directory.

Additional, the fix contains some more CMake improvements:
- Add "DOWNLOAD_EXTRACT_TIMESTAMP" to handle policy CMP0135 in CMake version 3.24 and above
- Using old behavior for policy CMP0169 to prevent warnings for deprecated FetchContent_Populate in newer CMake versions
- Add private headers installation destination to prevent CMake warnings
- Adds the possibilty to change the installation location for the CMake package files